### PR TITLE
Add Aetheron Sentinel L3 core package, JSON-RPC adapter, policy packs, tests, and CI scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # Aetheron-Sentinel-L3
-Features the Autonomous Interceptor that blocks the exact type of liquidity drain that crashed previous bridges.
+
+Aetheron Sentinel L3 is a reference implementation of an autonomous bridge-defense interceptor.
+
+## What was added now
+
+1. **JSON-RPC adapter with real polling flow**
+   - `JsonRpcOnChainAdapter` now supports pluggable transport, control-method routing, transaction submission, receipt polling, and finality checks.
+2. **Integration test coverage for RPC path**
+   - Added `tests/test_rpc_integration.py` with transport-mocked flow for submit, polling/finality, and rollback.
+3. **CI command matrix script**
+   - Added `scripts/ci_matrix.sh` to run `test_interceptor`, `test_readiness`, and `test_rpc_integration` suites separately.
+
+## Capability stack
+
+- `interceptor.py`: risk engine with actor/bridge/global breakers, policy-pack overrides, governance auto-rollback, crypto-agility compliance checks, and audit hooks.
+- `execution.py`: on-chain adapter abstraction + verified rollback-safe executor with failure budgets and operation receipts.
+- `rpc_adapter.py`: JSON-RPC integration adapter with polling and finality checks.
+- `policy_pack.py`: signed/versioned policy packs with staged rollout, dual-sign support, external PQ hooks, and rollback.
+- `pq_backend.py`: PQ backend protocol and mock implementation.
+- `state.py`: in-memory and Redis state backends for distributed counters/idempotency.
+- `governance.py`: calibration record tracking, drift alarming, and crypto-agility rules.
+- `simulation.py`: adversarial simulation + tournament KPI reporting.
+- `telemetry.py`: audit event sink interface.
+
+## Quick start
+
+```bash
+PYTHONPATH=src python -m unittest discover -s tests -v
+```
+
+## Recommendations
+
+- Run `scripts/ci_matrix.sh` in CI for explicit suite boundaries.
+- Run `scripts/premerge_stress.sh 5` before merge to execute repeated matrix runs with varying `PYTHONHASHSEED`.
+- Run `docs/BUG_BOUNTY_READINESS.md` checklist before public bounty launch.
+- Configure governance safe-mode thresholds so repeated critical drift alarms force `BLOCK` + `activate_kill_switch`.
+- Launch private bounty first, then widen scope after two clean staging cycles.

--- a/docs/BUG_BOUNTY_READINESS.md
+++ b/docs/BUG_BOUNTY_READINESS.md
@@ -1,0 +1,21 @@
+# Bug Bounty Readiness Checklist
+
+## 1) Real chain integration checks
+- Validate `JsonRpcOnChainAdapter` wiring against testnet endpoints.
+- Verify transaction finality and compensating rollback flows.
+
+## 2) PQ backend validation
+- Integrate `PQBackend` provider implementation.
+- Run dual-sign policy pack rollout in staging with automatic rollback drills.
+
+## 3) Abuse and chaos testing
+- Run idempotency flood tests and Redis retry/partition simulations.
+- Track false-positive and false-negative KPIs via tournament scenarios.
+
+## 4) Operational controls
+- Define kill-switch runbook with on-call ownership.
+- Add alert thresholds for governance critical drift and execution verification failures.
+
+## 5) Launch sequencing
+- Start with private bounty scope + capped blast radius.
+- Expand public scope only after two clean staging windows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "aetheron-sentinel-l3"
+version = "0.1.0"
+description = "Reference autonomous interceptor for bridge liquidity-drain defense"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "Aetheron"}]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/scripts/ci_matrix.sh
+++ b/scripts/ci_matrix.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PYTHONPATH=src
+
+python -m unittest -v tests.test_interceptor
+python -m unittest -v tests.test_readiness
+python -m unittest -v tests.test_rpc_integration

--- a/scripts/premerge_stress.sh
+++ b/scripts/premerge_stress.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ITERATIONS="${1:-5}"
+export PYTHONPATH=src
+
+if ! [[ "${ITERATIONS}" =~ ^[0-9]+$ ]] || [[ "${ITERATIONS}" -lt 1 ]]; then
+  echo "usage: $0 [iterations>=1]"
+  exit 2
+fi
+
+echo "Running pre-merge stress loop for ${ITERATIONS} iterations"
+for i in $(seq 1 "${ITERATIONS}"); do
+  export PYTHONHASHSEED="${i}"
+  echo "== iteration ${i}/${ITERATIONS} (PYTHONHASHSEED=${PYTHONHASHSEED}) =="
+  ./scripts/ci_matrix.sh
+done
+
+echo "Pre-merge stress loop completed successfully"

--- a/src/aetheron_sentinel_l3/__init__.py
+++ b/src/aetheron_sentinel_l3/__init__.py
@@ -1,0 +1,59 @@
+"""Aetheron Sentinel L3 package."""
+
+from .calibration import AdaptiveCalibrator, ThresholdConfig
+from .execution import ActionExecutor, ExecutionResult, OnChainAdapter, OperationReceipt, RuleBasedOnChainAdapter
+from .governance import CalibrationRecord, CryptoAgilityRule, DriftAlarm, GovernanceRegistry
+from .interceptor import InterceptorDecision, LiquidityRiskInput, PolicyProfile, SentinelInterceptor
+from .pq_backend import MockDilithiumBackend, PQBackend
+from .rpc_adapter import (
+    JsonRpcAdapterConfig,
+    JsonRpcAdapterError,
+    JsonRpcOnChainAdapter,
+    RpcResponseError,
+    RpcSubmissionError,
+    RpcTransportError,
+)
+from .policy import PolicyEngine, PolicyResult
+from .policy_pack import PolicyPack, PolicyPackManager
+from .simulation import AdversarialSimulator, SimulationMetrics, TournamentKPI
+from .state import InMemoryStateBackend, RedisStateBackend, StateBackend
+from .telemetry import AuditEvent, AuditSink, InMemoryAuditSink
+
+__all__ = [
+    "ActionExecutor",
+    "AdaptiveCalibrator",
+    "AdversarialSimulator",
+    "AuditEvent",
+    "AuditSink",
+    "CalibrationRecord",
+    "CryptoAgilityRule",
+    "DriftAlarm",
+    "ExecutionResult",
+    "GovernanceRegistry",
+    "InMemoryAuditSink",
+    "InMemoryStateBackend",
+    "InterceptorDecision",
+    "LiquidityRiskInput",
+    "JsonRpcAdapterConfig",
+    "JsonRpcAdapterError",
+    "JsonRpcOnChainAdapter",
+    "RuleBasedOnChainAdapter",
+    "OnChainAdapter",
+    "PQBackend",
+    "MockDilithiumBackend",
+    "OperationReceipt",
+    "PolicyEngine",
+    "PolicyPack",
+    "PolicyPackManager",
+    "PolicyProfile",
+    "PolicyResult",
+    "RedisStateBackend",
+    "RpcResponseError",
+    "RpcSubmissionError",
+    "RpcTransportError",
+    "SentinelInterceptor",
+    "SimulationMetrics",
+    "StateBackend",
+    "ThresholdConfig",
+    "TournamentKPI",
+]

--- a/src/aetheron_sentinel_l3/calibration.py
+++ b/src/aetheron_sentinel_l3/calibration.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ThresholdConfig:
+    throttle_threshold: float
+    block_threshold: float
+    max_hourly_drain_ratio: float
+    max_global_hourly_drain_ratio: float
+
+
+class AdaptiveCalibrator:
+    """Adaptive threshold calibrator with simple drift tracking.
+
+    Drift is measured as EWMA absolute error between observed risk and expected risk.
+    When drift is high, thresholds tighten. When low, thresholds relax to baseline.
+    """
+
+    def __init__(
+        self,
+        baseline: ThresholdConfig,
+        alpha: float = 0.15,
+        tighten_step: float = 0.03,
+        relax_step: float = 0.01,
+    ) -> None:
+        self._baseline = baseline
+        self._current = baseline
+        self._alpha = alpha
+        self._tighten_step = tighten_step
+        self._relax_step = relax_step
+        self._drift_ewma = 0.0
+
+    def update(self, observed_risk: float, expected_risk: float) -> None:
+        error = abs(observed_risk - expected_risk)
+        self._drift_ewma = self._alpha * error + (1 - self._alpha) * self._drift_ewma
+
+        if self._drift_ewma > 0.18:
+            self._current = ThresholdConfig(
+                throttle_threshold=max(0.15, self._current.throttle_threshold - self._tighten_step),
+                block_threshold=max(0.25, self._current.block_threshold - self._tighten_step),
+                max_hourly_drain_ratio=max(0.1, self._current.max_hourly_drain_ratio - self._tighten_step),
+                max_global_hourly_drain_ratio=max(0.15, self._current.max_global_hourly_drain_ratio - self._tighten_step),
+            )
+        elif self._drift_ewma < 0.06:
+            self._current = ThresholdConfig(
+                throttle_threshold=min(self._baseline.throttle_threshold, self._current.throttle_threshold + self._relax_step),
+                block_threshold=min(self._baseline.block_threshold, self._current.block_threshold + self._relax_step),
+                max_hourly_drain_ratio=min(self._baseline.max_hourly_drain_ratio, self._current.max_hourly_drain_ratio + self._relax_step),
+                max_global_hourly_drain_ratio=min(
+                    self._baseline.max_global_hourly_drain_ratio,
+                    self._current.max_global_hourly_drain_ratio + self._relax_step,
+                ),
+            )
+
+    def get_thresholds(self, chain_id: str, asset_symbol: str) -> ThresholdConfig:
+        """Per-chain/per-asset override hook.
+
+        This baseline implementation returns current global thresholds; callers may
+        subclass to support custom chain/asset overrides.
+        """
+
+        _ = (chain_id, asset_symbol)
+        return self._current
+
+    @property
+    def drift_score(self) -> float:
+        return self._drift_ewma

--- a/src/aetheron_sentinel_l3/execution.py
+++ b/src/aetheron_sentinel_l3/execution.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from itertools import count
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class OperationReceipt:
+    op_id: str
+    control: str
+    status: str
+    tx_hash: str
+    finalized: bool
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    applied: tuple[str, ...]
+    rolled_back: tuple[str, ...]
+    failures: tuple[str, ...]
+    verified: bool
+    receipts: tuple[OperationReceipt, ...]
+
+
+class OnChainAdapter:
+    def apply(self, control: str, op_id: str) -> OperationReceipt:
+        raise NotImplementedError
+
+    def rollback(self, control: str, op_id: str) -> None:
+        raise NotImplementedError
+
+    def verify(self, receipt: OperationReceipt) -> bool:
+        raise NotImplementedError
+
+
+class RuleBasedOnChainAdapter(OnChainAdapter):
+    """Concrete adapter mapping control names to apply/rollback functions."""
+
+    def __init__(
+        self,
+        apply_map: dict[str, Callable[[], None]] | None = None,
+        rollback_map: dict[str, Callable[[], None]] | None = None,
+        fail_controls: set[str] | None = None,
+        pending_controls: set[str] | None = None,
+    ) -> None:
+        self.apply_map = apply_map or {}
+        self.rollback_map = rollback_map or {}
+        self.fail_controls = fail_controls or set()
+        self.pending_controls = pending_controls or set()
+        self.applied_log: list[str] = []
+        self.rollback_log: list[str] = []
+
+    def apply(self, control: str, op_id: str) -> OperationReceipt:
+        if control in self.fail_controls:
+            raise RuntimeError(f"simulated failure for control: {control}")
+        fn = self.apply_map.get(control)
+        if fn is not None:
+            fn()
+        self.applied_log.append(control)
+        tx_hash = hashlib.sha256(f"{op_id}:{control}".encode("utf-8")).hexdigest()
+        finalized = control not in self.pending_controls
+        return OperationReceipt(op_id=op_id, control=control, status="applied", tx_hash=tx_hash, finalized=finalized)
+
+    def rollback(self, control: str, op_id: str) -> None:
+        fn = self.rollback_map.get(control)
+        if fn is not None:
+            fn()
+        self.rollback_log.append(control)
+
+    def verify(self, receipt: OperationReceipt) -> bool:
+        return receipt.control in self.applied_log and receipt.control not in self.rollback_log and receipt.finalized
+
+
+class ActionExecutor:
+    """Execution adapter for controls with rollback safety and failure budget."""
+
+    def __init__(self, chain_adapter: OnChainAdapter | None = None, failure_budget: int = 1) -> None:
+        self.chain_adapter = chain_adapter or RuleBasedOnChainAdapter()
+        self.failure_budget = failure_budget
+        self._seq = count(1)
+
+    def apply_controls(self, controls: tuple[str, ...]) -> ExecutionResult:
+        applied: list[str] = []
+        failures: list[str] = []
+        receipts: list[OperationReceipt] = []
+
+        for control in controls:
+            op_id = f"op-{next(self._seq)}"
+            try:
+                receipt = self.chain_adapter.apply(control, op_id)
+                receipts.append(receipt)
+                applied.append(control)
+            except Exception:
+                failures.append(control)
+                if len(failures) > self.failure_budget:
+                    rolled_back: list[str] = []
+                    for applied_control in reversed(applied):
+                        try:
+                            self.chain_adapter.rollback(applied_control, op_id=f"rollback-{next(self._seq)}")
+                            rolled_back.append(applied_control)
+                        except Exception:
+                            failures.append(f"rollback:{applied_control}")
+                    return ExecutionResult((), tuple(rolled_back), tuple(failures), False, tuple(receipts))
+
+        verified = all(self.chain_adapter.verify(r) for r in receipts)
+        return ExecutionResult(tuple(applied), (), tuple(failures), verified, tuple(receipts))

--- a/src/aetheron_sentinel_l3/governance.py
+++ b/src/aetheron_sentinel_l3/governance.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CalibrationRecord:
+    chain_id: str
+    asset_symbol: str
+    observed_drift: float
+    threshold_block: float
+
+
+@dataclass(frozen=True)
+class DriftAlarm:
+    chain_id: str
+    asset_symbol: str
+    drift: float
+    severity: str
+
+
+@dataclass(frozen=True)
+class CryptoAgilityRule:
+    minimum_scheme: str
+    grace_days_remaining: int
+
+
+class GovernanceRegistry:
+    """Tracks per-chain/asset calibration records, drift alarms, and crypto posture."""
+
+    def __init__(self, alarm_threshold: float = 0.2, max_critical_alarms_before_safe_mode: int = 3) -> None:
+        self.alarm_threshold = alarm_threshold
+        self.max_critical_alarms_before_safe_mode = max_critical_alarms_before_safe_mode
+        self.records: list[CalibrationRecord] = []
+        self.alarms: list[DriftAlarm] = []
+        self.crypto_rules: list[CryptoAgilityRule] = []
+        self.safe_mode = False
+
+    def record_calibration(self, record: CalibrationRecord) -> None:
+        self.records.append(record)
+        if record.observed_drift >= self.alarm_threshold:
+            severity = "critical" if record.observed_drift >= self.alarm_threshold * 1.5 else "warning"
+            alarm = DriftAlarm(
+                chain_id=record.chain_id,
+                asset_symbol=record.asset_symbol,
+                drift=record.observed_drift,
+                severity=severity,
+            )
+            self.alarms.append(alarm)
+            if severity == "critical":
+                recent_critical = sum(
+                    1 for a in self.alarms[-self.max_critical_alarms_before_safe_mode :] if a.severity == "critical"
+                )
+                if recent_critical >= self.max_critical_alarms_before_safe_mode:
+                    self.safe_mode = True
+
+    def register_crypto_rule(self, rule: CryptoAgilityRule) -> None:
+        self.crypto_rules.append(rule)
+
+    def clear_safe_mode(self) -> None:
+        self.safe_mode = False
+
+    def is_crypto_compliant(self, schemes: list[str]) -> bool:
+        if not self.crypto_rules:
+            return True
+        latest = self.crypto_rules[-1]
+        if latest.minimum_scheme == "pq-sim-dilithium":
+            return "pq-sim-dilithium" in schemes or latest.grace_days_remaining > 0
+        return True
+
+    def latest_for(self, chain_id: str, asset_symbol: str) -> CalibrationRecord | None:
+        for rec in reversed(self.records):
+            if rec.chain_id == chain_id and rec.asset_symbol == asset_symbol:
+                return rec
+        return None

--- a/src/aetheron_sentinel_l3/interceptor.py
+++ b/src/aetheron_sentinel_l3/interceptor.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .calibration import AdaptiveCalibrator, ThresholdConfig
+from .execution import ActionExecutor, ExecutionResult
+from .governance import CalibrationRecord, GovernanceRegistry
+from .policy import PolicyEngine
+from .policy_pack import PolicyPackManager
+from .state import InMemoryStateBackend, StateBackend
+from .telemetry import AuditEvent, AuditSink
+
+
+@dataclass(frozen=True)
+class LiquidityRiskInput:
+    amount: float
+    available_liquidity: float
+    velocity_1h: float
+    velocity_24h: float
+    anomaly_score: float
+    signer_quorum_ratio: float
+    chain_health_score: float = 1.0
+    oracle_deviation: float = 0.0
+    counterparty_risk: float = 0.0
+    bridge_id: str = "default"
+    chain_id: str = "default-chain"
+    asset_symbol: str = "UNKNOWN"
+    actor_id: str = "unknown-actor"
+    event_id: str | None = None
+
+
+@dataclass(frozen=True)
+class InterceptorDecision:
+    action: str
+    risk_score: float
+    reasons: tuple[str, ...]
+    controls: tuple[str, ...]
+    escalate: bool
+    risk_factors: tuple[tuple[str, float], ...]
+    execution: ExecutionResult | None
+
+
+@dataclass(frozen=True)
+class PolicyProfile:
+    name: str
+    throttle_threshold: float
+    block_threshold: float
+    max_hourly_drain_ratio: float
+    max_global_hourly_drain_ratio: float
+    max_actor_hourly_drain_ratio: float
+
+
+class SentinelInterceptor:
+    PROFILES: dict[str, PolicyProfile] = {
+        "aggressive": PolicyProfile("aggressive", 0.55, 0.8, 0.45, 0.55, 0.25),
+        "balanced": PolicyProfile("balanced", 0.45, 0.7, 0.35, 0.45, 0.2),
+        "conservative": PolicyProfile("conservative", 0.35, 0.6, 0.25, 0.35, 0.15),
+    }
+
+    def __init__(
+        self,
+        throttle_threshold: float = 0.45,
+        block_threshold: float = 0.7,
+        max_hourly_drain_ratio: float = 0.35,
+        max_global_hourly_drain_ratio: float = 0.45,
+        max_actor_hourly_drain_ratio: float = 0.2,
+        state_backend: StateBackend | None = None,
+        calibrator: AdaptiveCalibrator | None = None,
+        policy_engine: PolicyEngine | None = None,
+        policy_pack_manager: PolicyPackManager | None = None,
+        governance_registry: GovernanceRegistry | None = None,
+        executor: ActionExecutor | None = None,
+        audit_sink: AuditSink | None = None,
+        counter_ttl_seconds: int = 3600,
+        idempotency_ttl_seconds: int = 3600,
+    ) -> None:
+        self.throttle_threshold = throttle_threshold
+        self.block_threshold = block_threshold
+        self.max_hourly_drain_ratio = max_hourly_drain_ratio
+        self.max_global_hourly_drain_ratio = max_global_hourly_drain_ratio
+        self.max_actor_hourly_drain_ratio = max_actor_hourly_drain_ratio
+        self.state_backend = state_backend or InMemoryStateBackend()
+        self.calibrator = calibrator or AdaptiveCalibrator(
+            ThresholdConfig(throttle_threshold, block_threshold, max_hourly_drain_ratio, max_global_hourly_drain_ratio)
+        )
+        self.policy_engine = policy_engine or PolicyEngine()
+        self.policy_pack_manager = policy_pack_manager
+        self.governance_registry = governance_registry
+        self.executor = executor
+        self.audit_sink = audit_sink
+        self.counter_ttl_seconds = counter_ttl_seconds
+        self.idempotency_ttl_seconds = idempotency_ttl_seconds
+
+    @classmethod
+    def from_profile(cls, profile_name: str) -> "SentinelInterceptor":
+        p = cls.PROFILES[profile_name.lower()]
+        return cls(
+            throttle_threshold=p.throttle_threshold,
+            block_threshold=p.block_threshold,
+            max_hourly_drain_ratio=p.max_hourly_drain_ratio,
+            max_global_hourly_drain_ratio=p.max_global_hourly_drain_ratio,
+            max_actor_hourly_drain_ratio=p.max_actor_hourly_drain_ratio,
+        )
+
+    def evaluate(self, payload: LiquidityRiskInput) -> InterceptorDecision:
+        reasons: list[str] = []
+        liquidity = max(payload.available_liquidity, 1e-9)
+
+        if payload.event_id and not self.state_backend.register_event(payload.event_id, self.idempotency_ttl_seconds):
+            decision = InterceptorDecision("BLOCK", 1.0, ("duplicate_event",), ("drop_replay",), True, (), None)
+            self._audit(payload, decision)
+            return decision
+
+        thresholds = self.calibrator.get_thresholds(payload.chain_id, payload.asset_symbol)
+        thresholds = self._apply_policy_pack_threshold_overrides(payload, thresholds, reasons)
+
+        crypto_noncompliant = False
+        if self.governance_registry is not None and self.policy_pack_manager is not None and self.policy_pack_manager.active is not None:
+            pack = self.policy_pack_manager.active
+            schemes = [pack.signature_scheme]
+            if pack.secondary_signature_scheme is not None:
+                schemes.append(pack.secondary_signature_scheme)
+            if not self.governance_registry.is_crypto_compliant(schemes):
+                reasons.append("crypto_agility_noncompliant")
+                crypto_noncompliant = True
+
+        drain_ratio = min(payload.amount / liquidity, 1.5)
+        velocity_ratio = min(payload.velocity_1h / max(payload.velocity_24h / 24, 1e-6), 10)
+        anomaly = min(max(payload.anomaly_score, 0), 1)
+        quorum_penalty = 1 - min(max(payload.signer_quorum_ratio, 0), 1)
+        chain_penalty = 1 - min(max(payload.chain_health_score, 0), 1)
+        oracle_risk = min(max(payload.oracle_deviation, 0), 1)
+        counterparty_risk = min(max(payload.counterparty_risk, 0), 1)
+
+        if drain_ratio > 0.2:
+            reasons.append("high_drain_ratio")
+        if velocity_ratio > 3:
+            reasons.append("abnormal_withdrawal_velocity")
+        if anomaly > 0.65:
+            reasons.append("high_anomaly_score")
+        if quorum_penalty > 0.25:
+            reasons.append("low_signer_quorum")
+
+        bridge_outflow = self.state_backend.increment_counter(
+            f"bridge:{payload.bridge_id}:hourly_outflow", payload.amount, self.counter_ttl_seconds
+        )
+        global_outflow = self.state_backend.increment_counter("global:hourly_outflow", payload.amount, self.counter_ttl_seconds)
+        actor_outflow = self.state_backend.increment_counter(
+            f"actor:{payload.actor_id}:hourly_outflow", payload.amount, self.counter_ttl_seconds
+        )
+
+        if bridge_outflow / liquidity >= thresholds.max_hourly_drain_ratio:
+            reasons.append("bridge_circuit_breaker_triggered")
+        if global_outflow / liquidity >= thresholds.max_global_hourly_drain_ratio:
+            reasons.append("global_circuit_breaker_triggered")
+        if actor_outflow / liquidity >= self.max_actor_hourly_drain_ratio:
+            reasons.append("actor_circuit_breaker_triggered")
+
+        risk_components = {
+            "drain_ratio": 0.25 * min(drain_ratio, 1),
+            "velocity_ratio": 0.2 * min(velocity_ratio / 5, 1),
+            "anomaly": 0.2 * anomaly,
+            "quorum_penalty": 0.1 * quorum_penalty,
+            "oracle_risk": 0.1 * oracle_risk,
+            "counterparty_risk": 0.1 * counterparty_risk,
+            "chain_penalty": 0.05 * chain_penalty,
+        }
+        risk_score = max(0.0, min(sum(risk_components.values()), 1.0))
+
+        self.calibrator.update(observed_risk=risk_score, expected_risk=0.5)
+        self._governance_update(payload, risk_score, thresholds.block_threshold, reasons)
+
+        policy_result = self.policy_engine.evaluate(
+            drain_ratio=drain_ratio,
+            signer_quorum_ratio=payload.signer_quorum_ratio,
+            anomaly_score=anomaly,
+            chain_health_score=payload.chain_health_score,
+        )
+        reasons.extend(policy_result.reasons)
+        if self.governance_registry is not None and self.governance_registry.safe_mode:
+            reasons.append("governance_safe_mode")
+
+        if (
+            "bridge_circuit_breaker_triggered" in reasons
+            or "global_circuit_breaker_triggered" in reasons
+            or "actor_circuit_breaker_triggered" in reasons
+            or drain_ratio > 0.9
+            or anomaly > 0.95
+            or policy_result.force_action == "BLOCK"
+            or crypto_noncompliant
+            or "governance_safe_mode" in reasons
+        ):
+            action = "BLOCK"
+        elif risk_score >= thresholds.block_threshold:
+            action = "BLOCK"
+        elif risk_score >= thresholds.throttle_threshold:
+            action = "THROTTLE"
+        else:
+            action = "ALLOW"
+
+        controls = self._recommend_controls(reasons, action)
+        execution = self.executor.apply_controls(controls) if action in {"BLOCK", "THROTTLE"} and self.executor else None
+        decision = InterceptorDecision(
+            action,
+            risk_score,
+            tuple(sorted(set(reasons))),
+            controls,
+            action == "BLOCK" or "high_anomaly_score" in reasons,
+            tuple(sorted(risk_components.items())),
+            execution,
+        )
+        self._audit(payload, decision)
+        return decision
+
+    def _apply_policy_pack_threshold_overrides(
+        self,
+        payload: LiquidityRiskInput,
+        thresholds: ThresholdConfig,
+        reasons: list[str],
+    ) -> ThresholdConfig:
+        if self.policy_pack_manager is None or self.policy_pack_manager.active is None:
+            return thresholds
+
+        pack = self.policy_pack_manager.active
+        apply_pack = True
+        if pack.stage == "canary":
+            token = payload.event_id or payload.actor_id
+            apply_pack = (sum(ord(c) for c in token) % 100) < 10
+            if not apply_pack:
+                reasons.append("policy_pack_canary_skipped")
+
+        if not apply_pack:
+            return thresholds
+
+        reasons.append(f"policy_pack:{pack.version}:{pack.stage}")
+        return ThresholdConfig(
+            throttle_threshold=pack.rules.get("throttle_threshold", thresholds.throttle_threshold),
+            block_threshold=pack.rules.get("block_threshold", thresholds.block_threshold),
+            max_hourly_drain_ratio=pack.rules.get("max_hourly_drain_ratio", thresholds.max_hourly_drain_ratio),
+            max_global_hourly_drain_ratio=pack.rules.get(
+                "max_global_hourly_drain_ratio", thresholds.max_global_hourly_drain_ratio
+            ),
+        )
+
+    def _governance_update(self, payload: LiquidityRiskInput, risk_score: float, block_threshold: float, reasons: list[str]) -> None:
+        if self.governance_registry is None:
+            return
+        drift = abs(risk_score - 0.5)
+        self.governance_registry.record_calibration(
+            CalibrationRecord(payload.chain_id, payload.asset_symbol, drift, block_threshold)
+        )
+        if self.governance_registry.alarms and self.governance_registry.alarms[-1].severity == "critical":
+            reasons.append("governance_critical_drift")
+            if self.policy_pack_manager is not None and self.policy_pack_manager.has_history:
+                self.policy_pack_manager.rollback()
+                reasons.append("policy_pack_auto_rollback")
+
+    def _audit(self, payload: LiquidityRiskInput, decision: InterceptorDecision) -> None:
+        if self.audit_sink is None:
+            return
+        self.audit_sink.record(
+            AuditEvent(payload.event_id, decision.action, decision.risk_score, decision.reasons, decision.controls)
+        )
+
+    @staticmethod
+    def _recommend_controls(reasons: list[str], action: str) -> tuple[str, ...]:
+        controls: set[str] = set()
+        mapping = {
+            "high_drain_ratio": "enable_withdrawal_caps",
+            "abnormal_withdrawal_velocity": "add_time_delay",
+            "high_anomaly_score": "require_human_approval",
+            "low_signer_quorum": "raise_signer_quorum",
+            "bridge_circuit_breaker_triggered": "pause_bridge",
+            "global_circuit_breaker_triggered": "activate_network_guard",
+            "actor_circuit_breaker_triggered": "freeze_actor",
+            "duplicate_event": "drop_replay",
+            "governance_critical_drift": "freeze_policy_changes",
+            "governance_safe_mode": "activate_kill_switch",
+            "crypto_agility_noncompliant": "rotate_signature_scheme",
+        }
+        for reason, control in mapping.items():
+            if reason in reasons:
+                controls.add(control)
+        if action == "ALLOW":
+            controls.add("monitor")
+        return tuple(sorted(controls))

--- a/src/aetheron_sentinel_l3/policy.py
+++ b/src/aetheron_sentinel_l3/policy.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PolicyResult:
+    force_action: str | None
+    reasons: tuple[str, ...]
+
+
+class PolicyEngine:
+    """Simple policy engine + formal invariants layer.
+
+    This is a lightweight stand-in for OPA/Cedar style policy execution.
+    """
+
+    def evaluate(
+        self,
+        *,
+        drain_ratio: float,
+        signer_quorum_ratio: float,
+        anomaly_score: float,
+        chain_health_score: float,
+    ) -> PolicyResult:
+        reasons: list[str] = []
+        force_action: str | None = None
+
+        # Invariant: very large drains must never be auto-approved.
+        if drain_ratio >= 0.9:
+            reasons.append("invariant_large_drain_block")
+            force_action = "BLOCK"
+
+        # Invariant: critically low signer confidence cannot proceed.
+        if signer_quorum_ratio < 0.5:
+            reasons.append("invariant_low_quorum_block")
+            force_action = "BLOCK"
+
+        # Invariant: bad chain conditions + high anomaly must block.
+        if chain_health_score < 0.4 and anomaly_score > 0.7:
+            reasons.append("invariant_chain_anomaly_block")
+            force_action = "BLOCK"
+
+        return PolicyResult(force_action=force_action, reasons=tuple(sorted(set(reasons))))

--- a/src/aetheron_sentinel_l3/policy_pack.py
+++ b/src/aetheron_sentinel_l3/policy_pack.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class PolicyPack:
+    version: str
+    stage: str
+    rules: dict[str, float]
+    signature: str
+    signature_scheme: str = "hmac-sha256"
+    secondary_signature: str | None = None
+    secondary_signature_scheme: str | None = None
+
+
+class PolicyPackManager:
+    """Signed policy-pack manager with staged rollout, scheme agility, and rollback."""
+
+    def __init__(
+        self,
+        signing_key: str,
+        signature_scheme: str = "hmac-sha256",
+        secondary_signature_scheme: str | None = None,
+        pq_sign_fn: Callable[[str], str] | None = None,
+        pq_verify_fn: Callable[[str, str], bool] | None = None,
+    ) -> None:
+        self._signing_key = signing_key.encode("utf-8")
+        self.signature_scheme = signature_scheme
+        self.secondary_signature_scheme = secondary_signature_scheme
+        self.pq_sign_fn = pq_sign_fn
+        self.pq_verify_fn = pq_verify_fn
+        self._active: PolicyPack | None = None
+        self._history: list[PolicyPack] = []
+
+    def sign(self, version: str, stage: str, rules: dict[str, float], signature_scheme: str | None = None) -> PolicyPack:
+        primary = signature_scheme or self.signature_scheme
+        payload = self._payload(version, stage, rules, primary)
+        sig = self._sign_payload(payload, primary)
+
+        secondary_sig = None
+        secondary_scheme = self.secondary_signature_scheme
+        if secondary_scheme is not None:
+            secondary_payload = self._payload(version, stage, rules, secondary_scheme)
+            secondary_sig = self._sign_payload(secondary_payload, secondary_scheme)
+
+        return PolicyPack(version, stage, rules, sig, primary, secondary_sig, secondary_scheme)
+
+    def verify(self, pack: PolicyPack) -> bool:
+        payload = self._payload(pack.version, pack.stage, pack.rules, pack.signature_scheme)
+        primary_ok = self._verify_payload(payload, pack.signature_scheme, pack.signature)
+
+        if pack.secondary_signature is None:
+            return primary_ok
+        if pack.secondary_signature_scheme is None:
+            return False
+
+        secondary_payload = self._payload(pack.version, pack.stage, pack.rules, pack.secondary_signature_scheme)
+        secondary_ok = self._verify_payload(secondary_payload, pack.secondary_signature_scheme, pack.secondary_signature)
+        return primary_ok and secondary_ok
+
+    def rollout(self, pack: PolicyPack) -> None:
+        if not self.verify(pack):
+            raise ValueError("invalid policy pack signature")
+        if self._active is not None:
+            self._history.append(self._active)
+        self._active = pack
+
+    def rollback(self) -> None:
+        if not self._history:
+            raise RuntimeError("no prior policy pack to rollback to")
+        self._active = self._history.pop()
+
+    @property
+    def active(self) -> PolicyPack | None:
+        return self._active
+
+    @property
+    def has_history(self) -> bool:
+        return bool(self._history)
+
+    def _verify_payload(self, payload: str, scheme: str, signature: str) -> bool:
+        if scheme == "pq-ext":
+            if self.pq_verify_fn is None:
+                return False
+            return self.pq_verify_fn(payload, signature)
+        expected = self._sign_payload(payload, scheme)
+        return hmac.compare_digest(expected, signature)
+
+    def _sign_payload(self, payload: str, scheme: str) -> str:
+        if scheme == "hmac-sha256":
+            return hmac.new(self._signing_key, payload.encode("utf-8"), hashlib.sha256).hexdigest()
+        if scheme == "pq-sim-dilithium":
+            return "pq:" + hashlib.sha512((payload + self._signing_key.decode("utf-8")).encode("utf-8")).hexdigest()
+        if scheme == "pq-ext":
+            if self.pq_sign_fn is None:
+                raise ValueError("pq-ext signing requested but no pq_sign_fn provided")
+            return self.pq_sign_fn(payload)
+        raise ValueError(f"unsupported signature scheme: {scheme}")
+
+    @staticmethod
+    def _payload(version: str, stage: str, rules: dict[str, float], scheme: str) -> str:
+        return json.dumps({"version": version, "stage": stage, "rules": rules, "scheme": scheme}, sort_keys=True)

--- a/src/aetheron_sentinel_l3/pq_backend.py
+++ b/src/aetheron_sentinel_l3/pq_backend.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class PQBackend(Protocol):
+    def sign(self, payload: str) -> str:
+        ...
+
+    def verify(self, payload: str, signature: str) -> bool:
+        ...
+
+
+@dataclass
+class MockDilithiumBackend:
+    """Deterministic placeholder backend for PQ signing/verification integration tests."""
+
+    domain: str = "dilithium-mock-v1"
+
+    def sign(self, payload: str) -> str:
+        return "pqext:" + hashlib.sha512(f"{self.domain}:{payload}".encode("utf-8")).hexdigest()
+
+    def verify(self, payload: str, signature: str) -> bool:
+        return signature == self.sign(payload)

--- a/src/aetheron_sentinel_l3/rpc_adapter.py
+++ b/src/aetheron_sentinel_l3/rpc_adapter.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+from dataclasses import dataclass
+from itertools import count
+from typing import Callable
+
+from .execution import OnChainAdapter, OperationReceipt
+
+
+@dataclass
+class JsonRpcAdapterConfig:
+    chain_name: str
+    endpoint: str
+    confirmations_required: int = 1
+    poll_attempts: int = 3
+    poll_interval_seconds: float = 0.0
+    transport_retries: int = 0
+    retry_backoff_seconds: float = 0.0
+
+
+class JsonRpcAdapterError(RuntimeError):
+    """Base class for JSON-RPC adapter failures."""
+
+
+class RpcTransportError(JsonRpcAdapterError):
+    """Raised when the HTTP/transport layer fails."""
+
+
+class RpcSubmissionError(JsonRpcAdapterError):
+    """Raised when control submission does not return a valid tx hash."""
+
+
+class RpcResponseError(JsonRpcAdapterError):
+    """Raised for explicit JSON-RPC error payloads."""
+
+
+class JsonRpcOnChainAdapter(OnChainAdapter):
+    """JSON-RPC execution adapter with pluggable transport and receipt polling."""
+
+    def __init__(self, config: JsonRpcAdapterConfig, transport: Callable[[str, dict], dict] | None = None) -> None:
+        if config.confirmations_required < 1:
+            raise ValueError("confirmations_required must be >= 1")
+        if config.poll_attempts < 1:
+            raise ValueError("poll_attempts must be >= 1")
+        if config.poll_interval_seconds < 0:
+            raise ValueError("poll_interval_seconds must be >= 0")
+        if config.transport_retries < 0:
+            raise ValueError("transport_retries must be >= 0")
+        if config.retry_backoff_seconds < 0:
+            raise ValueError("retry_backoff_seconds must be >= 0")
+        self.config = config
+        self._transport = transport or self._default_transport
+        self._finalized: dict[str, bool] = {}
+        self._request_ids = count(1)
+
+    def apply(self, control: str, op_id: str) -> OperationReceipt:
+        submit_method = self._control_method(control)
+        tx_hash = self._rpc(submit_method, {"op_id": op_id, "control": control})
+        if not isinstance(tx_hash, str) or not tx_hash:
+            raise RpcSubmissionError("rpc submit returned invalid transaction hash")
+        finalized = self._wait_for_finality(tx_hash)
+        self._finalized[tx_hash] = finalized
+        return OperationReceipt(op_id=op_id, control=control, status="submitted", tx_hash=tx_hash, finalized=finalized)
+
+    def rollback(self, control: str, op_id: str) -> None:
+        _ = self._rpc("aetheron_rollbackControl", {"op_id": op_id, "control": control})
+
+    def verify(self, receipt: OperationReceipt) -> bool:
+        return self._finalized.get(receipt.tx_hash, False) and receipt.finalized
+
+    def _wait_for_finality(self, tx_hash: str) -> bool:
+        for attempt in range(self.config.poll_attempts):
+            receipt = self._rpc("eth_getTransactionReceipt", {"tx_hash": tx_hash})
+            if not isinstance(receipt, dict):
+                if self.config.poll_interval_seconds > 0 and attempt < self.config.poll_attempts - 1:
+                    time.sleep(self.config.poll_interval_seconds)
+                continue
+            status = receipt.get("status")
+            if status in {"0x0", 0, "failed"}:
+                return False
+            confirmations = self._parse_confirmations(receipt)
+            if confirmations >= self.config.confirmations_required:
+                return True
+            if self.config.poll_interval_seconds > 0 and attempt < self.config.poll_attempts - 1:
+                time.sleep(self.config.poll_interval_seconds)
+        return False
+
+    def _control_method(self, control: str) -> str:
+        return {
+            "pause_bridge": "aetheron_pauseBridge",
+            "enable_withdrawal_caps": "aetheron_setWithdrawalCaps",
+            "add_time_delay": "aetheron_setDelay",
+        }.get(control, "aetheron_applyControl")
+
+    def _rpc(self, method: str, params: dict):
+        response = None
+        for attempt in range(self.config.transport_retries + 1):
+            try:
+                response = self._transport(
+                    self.config.endpoint,
+                    {"jsonrpc": "2.0", "id": next(self._request_ids), "method": method, "params": [params]},
+                )
+                break
+            except Exception as exc:
+                if attempt >= self.config.transport_retries:
+                    raise RpcTransportError(f"transport failure for method {method}") from exc
+                if self.config.retry_backoff_seconds > 0:
+                    time.sleep(self.config.retry_backoff_seconds * (attempt + 1))
+        if not isinstance(response, dict):
+            raise RpcResponseError(f"rpc response is not an object for method {method}")
+        if "error" in response:
+            raise RpcResponseError(f"rpc error: {response['error']}")
+        return response.get("result")
+
+    @staticmethod
+    def _parse_confirmations(receipt: dict) -> int:
+        value = receipt.get("confirmations", 0)
+        try:
+            if isinstance(value, str):
+                if value.startswith("0x"):
+                    return int(value, 16)
+                return int(value)
+            if isinstance(value, int):
+                return value
+        except ValueError:
+            return 0
+        return 0
+
+    @staticmethod
+    def _default_transport(endpoint: str, payload: dict) -> dict:
+        req = urllib.request.Request(
+            endpoint,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read().decode("utf-8"))

--- a/src/aetheron_sentinel_l3/simulation.py
+++ b/src/aetheron_sentinel_l3/simulation.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .interceptor import LiquidityRiskInput, SentinelInterceptor
+
+
+@dataclass(frozen=True)
+class SimulationMetrics:
+    total: int
+    blocked: int
+    throttled: int
+    allowed: int
+    false_negatives: int
+    false_positives: int
+    true_positives: int
+
+
+@dataclass(frozen=True)
+class TournamentKPI:
+    tpr: float
+    fpr: float
+    mttr_minutes: float
+    economic_loss_prevented: float
+
+
+class AdversarialSimulator:
+    """Simple simulation harness for attack/benign scenarios."""
+
+    def __init__(self, interceptor: SentinelInterceptor) -> None:
+        self.interceptor = interceptor
+
+    def run(self, scenarios: list[tuple[LiquidityRiskInput, bool, float]]) -> SimulationMetrics:
+        blocked = throttled = allowed = false_negatives = false_positives = true_positives = 0
+
+        for payload, is_attack, _ in scenarios:
+            decision = self.interceptor.evaluate(payload)
+            flagged = decision.action in {"BLOCK", "THROTTLE"}
+
+            if decision.action == "BLOCK":
+                blocked += 1
+            elif decision.action == "THROTTLE":
+                throttled += 1
+            else:
+                allowed += 1
+
+            if is_attack and not flagged:
+                false_negatives += 1
+            if (not is_attack) and flagged:
+                false_positives += 1
+            if is_attack and flagged:
+                true_positives += 1
+
+        return SimulationMetrics(
+            total=len(scenarios),
+            blocked=blocked,
+            throttled=throttled,
+            allowed=allowed,
+            false_negatives=false_negatives,
+            false_positives=false_positives,
+            true_positives=true_positives,
+        )
+
+    def tournament(self, scenarios: list[tuple[LiquidityRiskInput, bool, float]]) -> TournamentKPI:
+        metrics = self.run(scenarios)
+        attacks = sum(1 for _, is_attack, _ in scenarios if is_attack)
+        benign = max(1, len(scenarios) - attacks)
+
+        prevented = 0.0
+        for payload, is_attack, est_loss in scenarios:
+            if not is_attack:
+                continue
+            decision = self.interceptor.evaluate(payload)
+            if decision.action in {"BLOCK", "THROTTLE"}:
+                prevented += est_loss
+
+        tpr = metrics.true_positives / max(1, attacks)
+        fpr = metrics.false_positives / benign
+        mttr_minutes = 3.0 if metrics.true_positives else 15.0
+
+        return TournamentKPI(
+            tpr=tpr,
+            fpr=fpr,
+            mttr_minutes=mttr_minutes,
+            economic_loss_prevented=prevented,
+        )

--- a/src/aetheron_sentinel_l3/state.py
+++ b/src/aetheron_sentinel_l3/state.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, Protocol
+
+
+class StateBackend(Protocol):
+    """Durable counter + idempotency backend abstraction."""
+
+    def register_event(self, event_key: str, ttl_seconds: int) -> bool:
+        """Returns True if event key is new, False if duplicate within TTL."""
+
+    def increment_counter(self, key: str, amount: float, ttl_seconds: int) -> float:
+        """Increments counter and returns updated value."""
+
+    def reset(self) -> None:
+        """Resets backend state (primarily for tests)."""
+
+
+@dataclass
+class _Entry:
+    value: float
+    expires_at: float
+
+
+class InMemoryStateBackend:
+    """In-memory backend with TTL semantics and idempotent key registry."""
+
+    def __init__(self, now_fn: Callable[[], float] | None = None) -> None:
+        self._now_fn = now_fn or time.time
+        self._counters: dict[str, _Entry] = {}
+        self._events: dict[str, float] = {}
+
+    def register_event(self, event_key: str, ttl_seconds: int) -> bool:
+        now = self._now_fn()
+        self._gc(now)
+        expires_at = now + ttl_seconds
+        current = self._events.get(event_key)
+        if current is not None and current > now:
+            return False
+        self._events[event_key] = expires_at
+        return True
+
+    def increment_counter(self, key: str, amount: float, ttl_seconds: int) -> float:
+        now = self._now_fn()
+        self._gc(now)
+        expires_at = now + ttl_seconds
+        existing = self._counters.get(key)
+        if existing is None or existing.expires_at <= now:
+            self._counters[key] = _Entry(value=amount, expires_at=expires_at)
+        else:
+            self._counters[key] = _Entry(value=existing.value + amount, expires_at=max(existing.expires_at, expires_at))
+        return self._counters[key].value
+
+    def reset(self) -> None:
+        self._counters.clear()
+        self._events.clear()
+
+    def _gc(self, now: float) -> None:
+        self._events = {k: v for k, v in self._events.items() if v > now}
+        self._counters = {k: v for k, v in self._counters.items() if v.expires_at > now}
+
+
+class RedisStateBackend:
+    """Redis backend for distributed breaker state and idempotency with retries."""
+
+    def __init__(self, redis_client, max_retries: int = 2) -> None:
+        self._redis = redis_client
+        self._max_retries = max_retries
+
+    def register_event(self, event_key: str, ttl_seconds: int) -> bool:
+        return bool(
+            self._retry(lambda: self._redis.set(name=f"event:{event_key}", value="1", ex=ttl_seconds, nx=True))
+        )
+
+    def increment_counter(self, key: str, amount: float, ttl_seconds: int) -> float:
+        def op() -> float:
+            pipe = self._redis.pipeline()
+            pipe.incrbyfloat(key, amount)
+            pipe.expire(key, ttl_seconds)
+            value, _ = pipe.execute()
+            return float(value)
+
+        return self._retry(op)
+
+    def reset(self) -> None:
+        raise NotImplementedError("reset is intentionally unsupported for production redis backend")
+
+    def _retry(self, fn):
+        last_error = None
+        for _ in range(self._max_retries + 1):
+            try:
+                return fn()
+            except Exception as exc:
+                last_error = exc
+        raise RuntimeError("redis backend unavailable after retries") from last_error

--- a/src/aetheron_sentinel_l3/telemetry.py
+++ b/src/aetheron_sentinel_l3/telemetry.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    event_id: str | None
+    action: str
+    risk_score: float
+    reasons: tuple[str, ...]
+    controls: tuple[str, ...]
+
+
+class AuditSink(Protocol):
+    def record(self, event: AuditEvent) -> None:
+        ...
+
+
+class InMemoryAuditSink:
+    def __init__(self) -> None:
+        self.events: list[AuditEvent] = []
+
+    def record(self, event: AuditEvent) -> None:
+        self.events.append(event)

--- a/tests/test_interceptor.py
+++ b/tests/test_interceptor.py
@@ -1,0 +1,236 @@
+import threading
+import unittest
+
+from aetheron_sentinel_l3.calibration import AdaptiveCalibrator, ThresholdConfig
+from aetheron_sentinel_l3.execution import ActionExecutor, RuleBasedOnChainAdapter
+from aetheron_sentinel_l3.governance import CalibrationRecord, CryptoAgilityRule, GovernanceRegistry
+from aetheron_sentinel_l3.interceptor import LiquidityRiskInput, SentinelInterceptor
+from aetheron_sentinel_l3.policy import PolicyEngine
+from aetheron_sentinel_l3.policy_pack import PolicyPackManager
+from aetheron_sentinel_l3.simulation import AdversarialSimulator
+from aetheron_sentinel_l3.state import InMemoryStateBackend, RedisStateBackend
+from aetheron_sentinel_l3.telemetry import InMemoryAuditSink
+
+
+class FakePipeline:
+    def __init__(self, parent):
+        self.parent = parent
+        self._key = None
+        self._amount = 0.0
+
+    def incrbyfloat(self, key, amount):
+        self._key = key
+        self._amount = amount
+
+    def expire(self, key, ttl):
+        _ = (key, ttl)
+
+    def execute(self):
+        with self.parent.lock:
+            if self.parent.failures_remaining > 0:
+                self.parent.failures_remaining -= 1
+                raise RuntimeError("partition")
+            self.parent.values[self._key] = self.parent.values.get(self._key, 0.0) + self._amount
+            return [self.parent.values[self._key], True]
+
+
+class FakeRedis:
+    def __init__(self):
+        self.values = {}
+        self.events = {}
+        self.failures_remaining = 0
+        self.lock = threading.Lock()
+
+    def set(self, name, value, ex, nx):
+        _ = (value, ex, nx)
+        with self.lock:
+            if self.failures_remaining > 0:
+                self.failures_remaining -= 1
+                raise RuntimeError("partition")
+            if name in self.events:
+                return False
+            self.events[name] = True
+            return True
+
+    def pipeline(self):
+        return FakePipeline(self)
+
+
+class TestSentinelInterceptor(unittest.TestCase):
+    def setUp(self) -> None:
+        self.interceptor = SentinelInterceptor()
+
+    def test_policy_pack_runtime_override(self) -> None:
+        manager = PolicyPackManager("secret")
+        pack = manager.sign("v1", "prod", {"block_threshold": 0.1})
+        manager.rollout(pack)
+        interceptor = SentinelInterceptor(policy_pack_manager=manager)
+        decision = interceptor.evaluate(LiquidityRiskInput(5000, 50_000, 1_500, 9_600, 0.8, 0.9, event_id="p1"))
+        self.assertEqual(decision.action, "BLOCK")
+        self.assertTrue(any(r.startswith("policy_pack:") for r in decision.reasons))
+
+    def test_governance_auto_rollback(self) -> None:
+        manager = PolicyPackManager("secret")
+        v1 = manager.sign("v1", "prod", {"block_threshold": 0.7})
+        v2 = manager.sign("v2", "prod", {"block_threshold": 0.6})
+        manager.rollout(v1)
+        manager.rollout(v2)
+        gov = GovernanceRegistry(alarm_threshold=0.2)
+        interceptor = SentinelInterceptor(policy_pack_manager=manager, governance_registry=gov)
+        decision = interceptor.evaluate(
+            LiquidityRiskInput(100, 50_000, 200, 9_600, 0.01, 1.0, chain_id="eth", asset_symbol="ETH", event_id="g1")
+        )
+        self.assertIn("policy_pack_auto_rollback", decision.reasons)
+        self.assertEqual(manager.active.version, "v1")
+
+    def test_governance_safe_mode_forces_block(self) -> None:
+        gov = GovernanceRegistry(alarm_threshold=0.2, max_critical_alarms_before_safe_mode=2)
+        interceptor = SentinelInterceptor(governance_registry=gov)
+        payload = LiquidityRiskInput(
+            100,
+            50_000,
+            200,
+            9_600,
+            0.01,
+            1.0,
+            chain_id="eth",
+            asset_symbol="ETH",
+        )
+        _ = interceptor.evaluate(payload)
+        decision = interceptor.evaluate(payload)
+        self.assertTrue(gov.safe_mode)
+        self.assertEqual(decision.action, "BLOCK")
+        self.assertIn("governance_safe_mode", decision.reasons)
+        self.assertIn("activate_kill_switch", decision.controls)
+
+    def test_execution_rollback_verified(self) -> None:
+        state = {"paused": False, "capped": False}
+
+        def pause(): state["paused"] = True
+        def unpause(): state["paused"] = False
+        def cap(): state["capped"] = True
+        def uncap(): state["capped"] = False
+
+        adapter = RuleBasedOnChainAdapter(
+            apply_map={"pause_bridge": pause, "enable_withdrawal_caps": cap},
+            rollback_map={"pause_bridge": unpause, "enable_withdrawal_caps": uncap},
+            fail_controls={"enable_withdrawal_caps"},
+        )
+        result = ActionExecutor(chain_adapter=adapter, failure_budget=0).apply_controls(("pause_bridge", "enable_withdrawal_caps"))
+        self.assertFalse(result.verified)
+        self.assertIn("pause_bridge", result.rolled_back)
+        self.assertFalse(state["paused"])
+        self.assertGreaterEqual(len(result.receipts), 1)
+
+    def test_execution_pending_receipt_not_verified(self) -> None:
+        adapter = RuleBasedOnChainAdapter(pending_controls={"pause_bridge"})
+        result = ActionExecutor(chain_adapter=adapter, failure_budget=1).apply_controls(("pause_bridge",))
+        self.assertFalse(result.verified)
+        self.assertEqual(result.receipts[0].finalized, False)
+
+    def test_execution_rollback_failure_recorded(self) -> None:
+        class RollbackFailAdapter(RuleBasedOnChainAdapter):
+            def rollback(self, control: str, op_id: str) -> None:
+                raise RuntimeError("rollback failed")
+
+        adapter = RollbackFailAdapter(fail_controls={"enable_withdrawal_caps"})
+        result = ActionExecutor(chain_adapter=adapter, failure_budget=0).apply_controls(("pause_bridge", "enable_withdrawal_caps"))
+        self.assertIn("rollback:pause_bridge", result.failures)
+        self.assertFalse(result.verified)
+
+    def test_redis_backend_retry_and_concurrent_idempotency(self) -> None:
+        client = FakeRedis()
+        backend = RedisStateBackend(client, max_retries=2)
+        client.failures_remaining = 1
+        self.assertTrue(backend.register_event("e1", 60))
+
+        results: list[bool] = []
+
+        def worker():
+            results.append(backend.register_event("same-event", 60))
+
+        threads = [threading.Thread(target=worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(sum(1 for r in results if r), 1)
+
+    def test_other_components_smoke(self) -> None:
+        self.assertEqual(SentinelInterceptor().evaluate(LiquidityRiskInput(50, 50_000, 200, 9600, 0.01, 1.0)).action, "ALLOW")
+        gov = GovernanceRegistry(alarm_threshold=0.2)
+        gov.record_calibration(CalibrationRecord("eth", "ETH", 0.31, 0.6))
+        self.assertEqual(gov.alarms[0].severity, "critical")
+        sim = AdversarialSimulator(SentinelInterceptor())
+        kpi = sim.tournament([(LiquidityRiskInput(49_000, 50_000, 20_000, 25_000, 0.95, 0.5, event_id="s2"), True, 100.0)])
+        self.assertGreaterEqual(kpi.tpr, 1.0)
+
+
+    def test_post_quantum_policy_pack_and_crypto_agility_enforcement(self) -> None:
+        manager = PolicyPackManager(
+            "secret",
+            signature_scheme="hmac-sha256",
+            secondary_signature_scheme="pq-sim-dilithium",
+        )
+        dual_pack = manager.sign("v-dual", "prod", {"block_threshold": 0.6})
+        manager.rollout(dual_pack)
+
+        gov = GovernanceRegistry()
+        gov.register_crypto_rule(CryptoAgilityRule(minimum_scheme="pq-sim-dilithium", grace_days_remaining=0))
+        interceptor = SentinelInterceptor(policy_pack_manager=manager, governance_registry=gov)
+        decision = interceptor.evaluate(LiquidityRiskInput(100, 50_000, 200, 9_600, 0.01, 1.0, event_id="pq-ok"))
+        self.assertNotIn("crypto_agility_noncompliant", decision.reasons)
+
+        hmac_manager = PolicyPackManager("secret", signature_scheme="hmac-sha256")
+        hmac_pack = hmac_manager.sign("v-hmac", "prod", {"block_threshold": 0.6})
+        hmac_manager.rollout(hmac_pack)
+        interceptor_bad = SentinelInterceptor(policy_pack_manager=hmac_manager, governance_registry=gov)
+        bad_decision = interceptor_bad.evaluate(LiquidityRiskInput(100, 50_000, 200, 9_600, 0.01, 1.0, event_id="pq-bad"))
+        self.assertIn("crypto_agility_noncompliant", bad_decision.reasons)
+
+    def test_pq_ext_signature_hook(self) -> None:
+        def pq_sign(payload: str) -> str:
+            return "ext:" + payload[::-1]
+
+        def pq_verify(payload: str, signature: str) -> bool:
+            return signature == "ext:" + payload[::-1]
+
+        manager = PolicyPackManager(
+            "secret",
+            signature_scheme="pq-ext",
+            pq_sign_fn=pq_sign,
+            pq_verify_fn=pq_verify,
+        )
+        pack = manager.sign("v-ext", "prod", {"block_threshold": 0.6})
+        manager.rollout(pack)
+        self.assertEqual(manager.active.version, "v-ext")
+
+    def test_audit_sink_and_di(self) -> None:
+        sink = InMemoryAuditSink()
+        interceptor = SentinelInterceptor(
+            state_backend=InMemoryStateBackend(),
+            calibrator=AdaptiveCalibrator(ThresholdConfig(0.45, 0.7, 0.35, 0.45)),
+            policy_engine=PolicyEngine(),
+            executor=ActionExecutor(),
+            audit_sink=sink,
+        )
+        interceptor.evaluate(LiquidityRiskInput(200, 50_000, 200, 9_600, 0.05, 1.0, event_id="audit"))
+        self.assertEqual(len(sink.events), 1)
+
+    def test_zero_liquidity_does_not_crash(self) -> None:
+        decision = self.interceptor.evaluate(
+            LiquidityRiskInput(
+                amount=10.0,
+                available_liquidity=0.0,
+                velocity_1h=10.0,
+                velocity_24h=100.0,
+                anomaly_score=0.2,
+                signer_quorum_ratio=1.0,
+            )
+        )
+        self.assertEqual(decision.action, "BLOCK")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,60 @@
+import random
+import unittest
+
+from aetheron_sentinel_l3.execution import ActionExecutor
+from aetheron_sentinel_l3.pq_backend import MockDilithiumBackend
+from aetheron_sentinel_l3.policy_pack import PolicyPackManager
+from aetheron_sentinel_l3.rpc_adapter import JsonRpcAdapterConfig, JsonRpcOnChainAdapter
+from aetheron_sentinel_l3.state import InMemoryStateBackend
+
+
+class TestReadiness(unittest.TestCase):
+    def test_rpc_adapter_receipt_verification(self) -> None:
+        def transport(_endpoint: str, payload: dict) -> dict:
+            if payload["method"].startswith("aetheron_"):
+                return {"result": "eth-sepolia:op-1:pause_bridge"}
+            if payload["method"] == "eth_getTransactionReceipt":
+                return {"result": {"confirmations": 2}}
+            return {"result": True}
+
+        adapter = JsonRpcOnChainAdapter(
+            JsonRpcAdapterConfig(chain_name="eth-sepolia", endpoint="https://example.invalid", confirmations_required=1),
+            transport=transport,
+        )
+        executor = ActionExecutor(chain_adapter=adapter)
+        result = executor.apply_controls(("pause_bridge",))
+        self.assertTrue(result.verified)
+        self.assertTrue(result.receipts[0].tx_hash.startswith("eth-sepolia:"))
+
+    def test_pq_backend_with_policy_manager(self) -> None:
+        backend = MockDilithiumBackend()
+        manager = PolicyPackManager(
+            "secret",
+            signature_scheme="pq-ext",
+            pq_sign_fn=backend.sign,
+            pq_verify_fn=backend.verify,
+        )
+        pack = manager.sign("v1", "prod", {"block_threshold": 0.6})
+        manager.rollout(pack)
+        self.assertEqual(manager.active.version, "v1")
+
+    def test_idempotency_flood_resilience(self) -> None:
+        backend = InMemoryStateBackend()
+        accepted = 0
+        for _ in range(500):
+            if backend.register_event("same-event", 60):
+                accepted += 1
+        self.assertEqual(accepted, 1)
+
+    def test_counter_stress(self) -> None:
+        backend = InMemoryStateBackend()
+        total = 0.0
+        for _ in range(1000):
+            amt = random.random()
+            total += amt
+            val = backend.increment_counter("k", amt, 60)
+        self.assertAlmostEqual(val, total, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rpc_integration.py
+++ b/tests/test_rpc_integration.py
@@ -1,0 +1,130 @@
+import unittest
+
+from aetheron_sentinel_l3.rpc_adapter import (
+    JsonRpcAdapterConfig,
+    JsonRpcOnChainAdapter,
+    RpcResponseError,
+    RpcSubmissionError,
+    RpcTransportError,
+)
+
+
+class FakeTransport:
+    def __init__(self):
+        self.calls = []
+        self.receipt_calls = 0
+
+    def __call__(self, endpoint: str, payload: dict) -> dict:
+        self.calls.append((endpoint, payload))
+        method = payload["method"]
+        if method.startswith("aetheron_") and method != "aetheron_rollbackControl":
+            return {"result": "0xtxhash"}
+        if method == "eth_getTransactionReceipt":
+            self.receipt_calls += 1
+            return {"result": {"confirmations": 2 if self.receipt_calls >= 2 else 0}}
+        if method == "aetheron_rollbackControl":
+            return {"result": True}
+        return {"error": "unknown"}
+
+
+class TestRpcIntegration(unittest.TestCase):
+    def test_invalid_config_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            JsonRpcOnChainAdapter(JsonRpcAdapterConfig(chain_name="eth", endpoint="http://example", poll_attempts=0))
+        with self.assertRaises(ValueError):
+            JsonRpcOnChainAdapter(
+                JsonRpcAdapterConfig(chain_name="eth", endpoint="http://example", confirmations_required=0)
+            )
+        with self.assertRaises(ValueError):
+            JsonRpcOnChainAdapter(
+                JsonRpcAdapterConfig(chain_name="eth", endpoint="http://example", transport_retries=-1)
+            )
+
+    def test_apply_and_finalize(self) -> None:
+        transport = FakeTransport()
+        adapter = JsonRpcOnChainAdapter(
+            JsonRpcAdapterConfig(chain_name="eth-sepolia", endpoint="http://example", confirmations_required=2, poll_attempts=3),
+            transport=transport,
+        )
+        receipt = adapter.apply("pause_bridge", "op-1")
+        self.assertTrue(receipt.finalized)
+        self.assertTrue(adapter.verify(receipt))
+
+    def test_rollback(self) -> None:
+        transport = FakeTransport()
+        adapter = JsonRpcOnChainAdapter(JsonRpcAdapterConfig(chain_name="eth-sepolia", endpoint="http://example"), transport=transport)
+        adapter.rollback("pause_bridge", "op-2")
+        self.assertTrue(any(call[1]["method"] == "aetheron_rollbackControl" for call in transport.calls))
+
+    def test_failed_transaction_is_not_finalized(self) -> None:
+        def failed_transport(_endpoint: str, payload: dict) -> dict:
+            if payload["method"].startswith("aetheron_") and payload["method"] != "aetheron_rollbackControl":
+                return {"result": "0xtxhash"}
+            if payload["method"] == "eth_getTransactionReceipt":
+                return {"result": {"status": "0x0", "confirmations": 100}}
+            return {"result": True}
+
+        adapter = JsonRpcOnChainAdapter(JsonRpcAdapterConfig(chain_name="eth-sepolia", endpoint="http://example"), transport=failed_transport)
+        receipt = adapter.apply("pause_bridge", "op-3")
+        self.assertFalse(receipt.finalized)
+        self.assertFalse(adapter.verify(receipt))
+
+    def test_invalid_submit_hash_raises(self) -> None:
+        def invalid_submit_transport(_endpoint: str, payload: dict) -> dict:
+            if payload["method"].startswith("aetheron_"):
+                return {"result": ""}
+            return {"result": {"confirmations": 3}}
+
+        adapter = JsonRpcOnChainAdapter(
+            JsonRpcAdapterConfig(chain_name="eth-sepolia", endpoint="http://example"),
+            transport=invalid_submit_transport,
+        )
+        with self.assertRaises(RpcSubmissionError):
+            adapter.apply("pause_bridge", "op-4")
+
+    def test_transport_exception_wrapped(self) -> None:
+        def exploding_transport(_endpoint: str, _payload: dict) -> dict:
+            raise TimeoutError("network timeout")
+
+        adapter = JsonRpcOnChainAdapter(
+            JsonRpcAdapterConfig(chain_name="eth-sepolia", endpoint="http://example"),
+            transport=exploding_transport,
+        )
+        with self.assertRaises(RpcTransportError):
+            adapter.apply("pause_bridge", "op-5")
+
+    def test_transport_retry_then_success(self) -> None:
+        calls = {"count": 0}
+
+        def flaky_transport(_endpoint: str, payload: dict) -> dict:
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise TimeoutError("network timeout")
+            if payload["method"].startswith("aetheron_"):
+                return {"result": "0xtxhash"}
+            if payload["method"] == "eth_getTransactionReceipt":
+                return {"result": {"confirmations": 3}}
+            return {"result": True}
+
+        adapter = JsonRpcOnChainAdapter(
+            JsonRpcAdapterConfig(chain_name="eth-sepolia", endpoint="http://example", transport_retries=1),
+            transport=flaky_transport,
+        )
+        receipt = adapter.apply("pause_bridge", "op-retry")
+        self.assertTrue(receipt.finalized)
+        self.assertGreaterEqual(calls["count"], 2)
+
+    def test_non_dict_response_raises(self) -> None:
+        def invalid_response_transport(_endpoint: str, _payload: dict):
+            return "not-json-object"
+
+        adapter = JsonRpcOnChainAdapter(
+            JsonRpcAdapterConfig(chain_name="eth-sepolia", endpoint="http://example"),
+            transport=invalid_response_transport,
+        )
+        with self.assertRaises(RpcResponseError):
+            adapter.apply("pause_bridge", "op-6")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a reference implementation of an autonomous bridge-defense interceptor with pluggable execution and governance controls. 
- Add a JSON-RPC on-chain adapter that supports submission, polling, finality checks and transport retry/backoff for realistic integration flows. 
- Improve test coverage and CI hygiene by adding integration/unit tests and simple CI/stress scripts to validate runtime behaviors.

### Description

- Add a new Python package under `src/aetheron_sentinel_l3` exposing core modules including `interceptor`, `execution`, `rpc_adapter`, `policy_pack`, `policy`, `governance`, `state`, `calibration`, `telemetry`, `simulation`, and `pq_backend`, and export them via `__init__.py`.
- Implement execution and rollback primitives with `ActionExecutor`, `RuleBasedOnChainAdapter`, and `OperationReceipt`, plus a `JsonRpcOnChainAdapter` that implements submission, polling (`_wait_for_finality`), transport retries, and result parsing.
- Implement signed/staged `PolicyPackManager` with multiple signature schemes (HMAC, simulated PQ, and pluggable `pq-ext`), governance registry and calibrator (`AdaptiveCalibrator`), in-memory and Redis-backed state backends, and audit sink support.
- Add test suites (`tests/test_interceptor.py`, `tests/test_readiness.py`, `tests/test_rpc_integration.py`), CI helpers (`scripts/ci_matrix.sh`, `scripts/premerge_stress.sh`), `pyproject.toml`, `README.md` updates, `.gitignore`, and a `docs/BUG_BOUNTY_READINESS.md` checklist.

### Testing

- Ran the unit/integration suites via the CI matrix script which executes `python -m unittest -v tests.test_interceptor`, `python -m unittest -v tests.test_readiness`, and `python -m unittest -v tests.test_rpc_integration`, and all suites passed. 
- Verified `JsonRpcOnChainAdapter` behaviors including transport retry, receipt polling/finality, invalid submit handling, and rollback invocation via `tests/test_rpc_integration.py` which passed. 
- Exercised execution semantics including failure-budgeted rollbacks, pending receipts, and rollback failure recording via `tests/test_interceptor.py` which passed. 
- Exercised state backend idempotency and counter stress scenarios via `tests/test_readiness.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cdfda7a620832fb283f0bb0dc2c760)