### PR TITLE
Add optional post-quantum backend with runtime guard, docs, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Aetheron Sentinel L3 is a reference implementation of an autonomous bridge-defen
 PYTHONPATH=src python -m unittest discover -s tests -v
 ```
 
+## Optional post-quantum dependency
+
+- `MockDilithiumBackend` is deterministic and does **not** require external PQ libraries.
+- `RealDilithiumBackend` requires an installed provider for the `dilithium_py` module at runtime.
+- If `dilithium_py` is missing, `RealDilithiumBackend` raises `ModuleNotFoundError` during initialization.
+
 ## Recommendations
 
 - Run `scripts/ci_matrix.sh` in CI for explicit suite boundaries.

--- a/scripts/ci_matrix.sh
+++ b/scripts/ci_matrix.sh
@@ -6,3 +6,4 @@ export PYTHONPATH=src
 python -m unittest -v tests.test_interceptor
 python -m unittest -v tests.test_readiness
 python -m unittest -v tests.test_rpc_integration
+python -m unittest -v tests.test_pq_backend

--- a/src/aetheron_sentinel_l3/pq_backend.py
+++ b/src/aetheron_sentinel_l3/pq_backend.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 from dataclasses import dataclass
 from typing import Protocol
-
-from dilithium_py import dilithium
-
 
 class PQBackend(Protocol):
     def sign(self, payload: str) -> str: ...
@@ -33,18 +31,27 @@ class RealDilithiumBackend:
     """Real Dilithium post-quantum signature backend."""
 
     def __init__(self) -> None:
-        self.sk, self.pk = dilithium.Dilithium2.keygen()
-        self.sk_packed = dilithium.Dilithium2._pack_sk(*self.sk)
-        self.pk_packed = dilithium.Dilithium2._pack_pk(*self.pk)
+        if importlib.util.find_spec("dilithium_py") is None:
+            raise ModuleNotFoundError(
+                "RealDilithiumBackend requires optional dependency 'dilithium_py'."
+            )
+        from dilithium_py import dilithium
+
+        self._dilithium = dilithium
+        self.sk, self.pk = self._dilithium.Dilithium2.keygen()
+        self.sk_packed = self._dilithium.Dilithium2._pack_sk(*self.sk)
+        self.pk_packed = self._dilithium.Dilithium2._pack_pk(*self.pk)
 
     def sign(self, payload: str) -> str:
-        signature = dilithium.Dilithium2.sign(self.sk_packed, payload.encode("utf-8"))
+        signature = self._dilithium.Dilithium2.sign(
+            self.sk_packed, payload.encode("utf-8")
+        )
         return signature.hex()
 
     def verify(self, payload: str, signature: str) -> bool:
         try:
             sig_bytes = bytes.fromhex(signature)
-            return dilithium.Dilithium2.verify(
+            return self._dilithium.Dilithium2.verify(
                 self.pk_packed, sig_bytes, payload.encode("utf-8")
             )
         except Exception:

--- a/tests/test_pq_backend.py
+++ b/tests/test_pq_backend.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import patch
+
+from aetheron_sentinel_l3.pq_backend import MockDilithiumBackend, RealDilithiumBackend
+
+
+class TestPQBackend(unittest.TestCase):
+    def test_mock_backend_roundtrip(self) -> None:
+        backend = MockDilithiumBackend()
+        payload = "bridge:pause"
+        signature = backend.sign(payload)
+
+        self.assertTrue(signature.startswith("pqext:"))
+        self.assertTrue(backend.verify(payload, signature))
+        self.assertFalse(backend.verify("bridge:resume", signature))
+
+    def test_real_backend_requires_optional_dependency(self) -> None:
+        with patch("importlib.util.find_spec", return_value=None):
+            with self.assertRaises(ModuleNotFoundError) as ctx:
+                RealDilithiumBackend()
+
+        self.assertIn("dilithium_py", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide an optional RealDilithiumBackend for post-quantum signing while avoiding hard dependency on `dilithium_py` at import time.
- Document runtime behavior and ensure CI/test coverage for the PQ backend codepath.

### Description

- Add `importlib.util.find_spec`-based guard and deferred import in `RealDilithiumBackend` to raise `ModuleNotFoundError` if `dilithium_py` is not installed and to keep the top-level module import-free.
- Retain deterministic `MockDilithiumBackend` and switch `RealDilithiumBackend` to store the imported module as `_dilithium` and use it for keygen/sign/verify calls.
- Add `tests/test_pq_backend.py` to validate the mock backend round-trip behavior and that `RealDilithiumBackend` raises when the optional dependency is missing.
- Update `scripts/ci_matrix.sh` to include the new `tests.test_pq_backend` suite and add README notes describing the optional PQ dependency and backend behaviors.

### Testing

- Ran `python -m unittest -v tests.test_pq_backend` which verifies mock sign/verify and the dependency guard, and it succeeded.
- CI matrix updated to run `tests.test_interceptor`, `tests.test_readiness`, `tests.test_rpc_integration`, and `tests.test_pq_backend` as separate suites (all suites passed in local runs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de586340a4832f98f969cda2dc546c)