### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/site/script.js
+++ b/site/script.js
@@ -437,7 +437,7 @@ class SentinelInterface {
       const currentTVL = metrics[0].textContent;
       if (currentTVL && currentTVL.includes('B')) {
         const baseValue = parseFloat(
-          currentTVL.replace('$', '').replace('B+', ''),
+          currentTVL.replace(/\$/g, '').replace(/B\+/g, ''),
         );
         const newValue = (baseValue + Math.random() * 0.1).toFixed(1);
         metrics[0].textContent = `$${newValue}B+`;


### PR DESCRIPTION
Potential fix for [https://github.com/MastaTrill/Aetheron-Sentinel-L3/security/code-scanning/1](https://github.com/MastaTrill/Aetheron-Sentinel-L3/security/code-scanning/1)

Use global regular-expression replacements so **all** occurrences of formatting tokens are removed before `parseFloat`.

Best fix in `site/script.js` around line 440:
- Change:
  - `currentTVL.replace('$', '').replace('B+', '')`
- To:
  - `currentTVL.replace(/\$/g, '').replace(/B\+/g, '')`

This keeps existing functionality (extract numeric part from strings like `$12.3B+`) while avoiding partial replacement bugs. No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
