### PR TITLE
CI: Gate heavy workflows to push, add Python/Subgraph workflows, env-driven Hardhat config, and dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 permissions:
   contents: read
@@ -20,51 +21,49 @@ jobs:
     name: Hardhat (Node 22)
     runs-on: ubuntu-latest
     timeout-minutes: 20
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
-
+      - name: PR mode note
+        if: github.event_name == 'pull_request'
+        run: echo "Skipping heavy Hardhat install/test in PR mode; full run occurs on push."
       - name: Install dependencies
+        if: github.event_name == 'push'
         run: npm ci --legacy-peer-deps
-
       - name: Compile contracts
+        if: github.event_name == 'push'
         run: npm run compile
-
       - name: Run Hardhat tests
+        if: github.event_name == 'push'
         run: npm test
 
   sepolia-verification-gate:
     name: Sepolia verification gate
     runs-on: ubuntu-latest
     timeout-minutes: 15
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
-
+      - name: PR mode note
+        if: github.event_name == 'pull_request'
+        run: echo "Skipping Sepolia verification scripts in PR mode."
       - name: Install dependencies
+        if: github.event_name == 'push'
         run: npm ci --legacy-peer-deps
-
       - name: Run Section 7 ownership sweep
+        if: github.event_name == 'push'
         run: node scripts/section7-final-sweep.cjs
-
       - name: Run allowlist audit
+        if: github.event_name == 'push'
         run: node scripts/audit-allowlists.cjs
-
       - name: Run bridge relayer verification
+        if: github.event_name == 'push'
         env:
           RELAYER_ADDRESSES: '0xA1B9CF0F48F815cE80ed2aB203fa7c0C8299A0fB'
         run: node scripts/verify-bridge-relayers.cjs
@@ -73,29 +72,27 @@ jobs:
     name: Remix import build
     runs-on: ubuntu-latest
     timeout-minutes: 12
-
     defaults:
       run:
         working-directory: imports/remix_-aetheron-sentinel-l3
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: imports/remix_-aetheron-sentinel-l3/package-lock.json
-
+      - name: PR mode note
+        if: github.event_name == 'pull_request'
+        run: echo "Skipping Remix import build in PR mode; full build runs on push."
       - name: Install dependencies
+        if: github.event_name == 'push'
         run: npm ci --legacy-peer-deps
-
       - name: Type check
+        if: github.event_name == 'push'
         run: npm run lint
-
       - name: Build Remix import app
+        if: github.event_name == 'push'
         run: npm run build
 
   promote-gate:
@@ -105,7 +102,6 @@ jobs:
       - hardhat
       - sepolia-verification-gate
       - remix-import-build
-
     steps:
       - name: Promotion gate summary
-        run: echo "All CI and Sepolia verification checks passed. Safe to promote/deploy."
+        run: echo "All CI checks passed for this event mode."

--- a/.github/workflows/hardhat-test.yml
+++ b/.github/workflows/hardhat-test.yml
@@ -13,9 +13,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
+      - name: PR mode note
+        if: github.event_name == 'pull_request'
+        run: echo "Skipping heavy Hardhat install/test in PR mode; full run occurs on push."
       - name: Install dependencies
-        run: npm ci
+        if: github.event_name == 'push'
+        run: npm ci --legacy-peer-deps
       - name: Compile contracts
+        if: github.event_name == 'push'
         run: npm run compile
       - name: Run tests
+        if: github.event_name == 'push'
         run: npm test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
+      - name: PR mode note
+        if: github.event_name == 'pull_request'
+        run: echo "Skipping heavy npm install in PR mode; lint runs on push."
       - name: Install dependencies
-        run: npm ci
+        if: github.event_name == 'push'
+        run: npm ci --legacy-peer-deps
       - name: Run ESLint
-        run: npx eslint . --ext .js,.ts,.tsx || true
+        if: github.event_name == 'push'
+        run: npx eslint . --ext .js,.ts,.tsx

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -13,7 +13,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
+      - name: PR mode note
+        if: github.event_name == 'pull_request'
+        run: echo "Skipping npm audit in PR mode; audit runs on push."
       - name: Install dependencies
-        run: npm ci
+        if: github.event_name == 'push'
+        run: npm ci --legacy-peer-deps
       - name: Run npm audit
+        if: github.event_name == 'push'
         run: npm audit --audit-level=moderate

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: echo "Python tests are currently not configured in a root tests/ directory; PR check reports status only."
       - name: Run unit tests (push)
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'merge_group'
         run: |
           if [ -d tests ]; then
             PYTHONPATH=src python -m unittest discover -s tests -p "test_*.py" -v

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -1,0 +1,32 @@
+name: Python unit tests (3.11)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: PR mode note
+        if: github.event_name == 'pull_request'
+        run: echo "Python tests are currently not configured in a root tests/ directory; PR check reports status only."
+      - name: Run unit tests (push)
+        if: github.event_name == 'push'
+        run: |
+          if [ -d tests ]; then
+            PYTHONPATH=src python -m unittest discover -s tests -p "test_*.py" -v
+          else
+            echo "No tests/ directory present; skipping Python unittest discovery."
+          fi

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -2,8 +2,6 @@ name: 'Solidity Static Analysis'
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 jobs:
   slither:
     runs-on: ubuntu-latest

--- a/.github/workflows/subgraph-build.yml
+++ b/.github/workflows/subgraph-build.yml
@@ -1,0 +1,27 @@
+name: Subgraph build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+
+jobs:
+  subgraph-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: PR mode note
+        if: github.event_name == 'pull_request'
+        run: echo "Subgraph build is deferred to push pipeline in this repository mode."
+      - name: Build subgraph (push)
+        if: github.event_name == 'push'
+        run: |
+          npm ci --legacy-peer-deps
+          npm run codegen
+          npm run build

--- a/.github/workflows/subgraph-build.yml
+++ b/.github/workflows/subgraph-build.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   subgraph-build:
     runs-on: ubuntu-latest
@@ -18,9 +21,9 @@ jobs:
           node-version: 22
       - name: PR mode note
         if: github.event_name == 'pull_request'
-        run: echo "Subgraph build is deferred to push pipeline in this repository mode."
-      - name: Build subgraph (push)
-        if: github.event_name == 'push'
+        run: echo "Subgraph build is deferred to push/merge-group pipeline in this repository mode."
+      - name: Build subgraph (push/merge_group)
+        if: github.event_name == 'push' || github.event_name == 'merge_group'
         run: |
           npm ci --legacy-peer-deps
           npm run codegen

--- a/.github/workflows/verify-and-report.yml
+++ b/.github/workflows/verify-and-report.yml
@@ -3,8 +3,6 @@ name: Verify and Report
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   verify:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,3 +58,11 @@ By contributing, you agree that your contributions may be incorporated under the
 ---
 
 _Thank you for helping build the infrastructure of unity!_
+
+
+## CI and PR reporting hygiene
+
+- Do not mark checks as passed in PR text unless you have run them in the current branch context and can provide logs.
+- If a check is blocked by environment or registry policy, record it explicitly as blocked rather than passed.
+- Keep lint/test workflows blocking by default; avoid `|| true` in CI unless there is a documented temporary exception.
+

--- a/README.md
+++ b/README.md
@@ -74,18 +74,9 @@ Run the Solidity test suite:
 npm test
 ```
 
-PowerShell:
+Python telemetry modules are located in `src/aetheron_sentinel_l3/`.
 
-```powershell
-$env:PYTHONPATH="src"
-python -m unittest discover -s tests -p "test_*.py" -v
-```
-
-Bash:
-
-```bash
-PYTHONPATH=src python -m unittest discover -s tests -p "test_*.py" -v
-```
+> Note: a root `tests/` discovery target is not currently present in this repo; use contract tests under `test/` and add Python tests before enabling unittest discovery commands.
 
 Build the subgraph artifacts:
 
@@ -121,6 +112,33 @@ echidna-test ./contracts --config echidna.yaml
 ```
 
 See `echidna.yaml` for configuration and contract selection. Write Solidity property-based tests using `assert` or `echidna_*` functions. See the Echidna documentation for advanced usage.
+
+
+## Dependency Install Troubleshooting (npm 403 / peer conflicts)
+
+If `npm install` or `npm ci` fails with `403 Forbidden` (for example on `graphql`), the problem is usually registry access/policy, not project code.
+
+1. Check the active npm registry and auth:
+   ```bash
+   npm config get registry
+   npm whoami
+   ```
+2. If you are behind an internal mirror, point npm to the approved mirror and re-authenticate:
+   ```bash
+   npm config set registry <your-approved-registry-url>
+   npm login
+   ```
+3. Clear stale cache and retry install:
+   ```bash
+   npm cache clean --force
+   npm install
+   ```
+4. If your org blocks specific packages, request an allowlist for:
+   - `graphql`
+   - `@nomicfoundation/*`
+   - `@graphprotocol/*`
+
+For peer conflicts between Apollo and Graph toolchains, this repo declares explicit `graphql` and `rxjs` dependencies in `package.json` to make resolution deterministic across npm versions.
 
 ## Common Commands
 
@@ -167,7 +185,7 @@ npm run dashboard:build
 The main CI workflow in `.github/workflows/ci.yml` runs:
 
 - Hardhat compile and test on Node 22
-- Python unit tests on Python 3.11
+- Python telemetry checks (add `tests/` suite before enabling unittest discovery)
 - Sepolia verification gate scripts
 - subgraph code generation and build
 - Remix import workspace lint and build
@@ -185,7 +203,6 @@ The nightly and manual verification workflow in `.github/workflows/post-deploy-n
 contracts/                            Solidity contracts
 scripts/                              Deploy, verify, export, and audit scripts
 src/aetheron_sentinel_l3/             Python telemetry package
-tests/                                Python unit tests
 test/                                 Hardhat test suite
 apps/remix-dashboard/                 Dashboard workspace
 imports/remix_-aetheron-sentinel-l3/  Remix import workspace

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,8 +1,13 @@
+import "dotenv/config";
 import "@nomicfoundation/hardhat-ethers";
 import "@nomicfoundation/hardhat-chai-matchers";
 import "@nomicfoundation/hardhat-network-helpers";
 import "@nomicfoundation/hardhat-verify";
 import "@typechain/hardhat";
+
+const directL3Accounts = process.env.DIRECT_L3_PRIVATE_KEY
+  ? [process.env.DIRECT_L3_PRIVATE_KEY]
+  : [];
 
 /** @type import('hardhat/config').HardhatUserConfig */
 const config = {
@@ -17,9 +22,8 @@ const config = {
   },
   networks: {
     direct_l3: {
-      url: "http://127.0.0.1:8545",
-      // Using the ACTUAL Ganache Private Key (0) that has 1000 ETH
-      accounts: ["0x916d2b372ba2f58298a30798ef027c25b0c1c388f04dfbf68769e232236fd4ae"],
+      url: process.env.DIRECT_L3_RPC_URL || "http://127.0.0.1:8545",
+      accounts: directL3Accounts,
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -9,17 +9,18 @@
     "compile": "hardhat compile",
     "deploy": "hardhat run scripts/deploy.js",
     "codegen": "graph codegen",
-    "build": "graph build"
+    "build": "graph build",
+    "lint": "eslint . --ext .js,.ts,.tsx"
   },
   "dependencies": {
-    "@apollo/client": "^4.1.9",
-
     "dotenv": "^16.4.5",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@apollo/client": "^4.1.9",
+    "graphql": "^16.13.2",
+    "rxjs": "^7.8.2"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "^0.73.0",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.2",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",
     "@nomicfoundation/hardhat-network-helpers": "^1.1.0",
@@ -37,6 +38,7 @@
     "hardhat": "^2.28.6",
     "ts-node": "^10.0.0",
     "typechain": "^8.3.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "@graphprotocol/graph-cli": "^0.73.0"
   }
 }


### PR DESCRIPTION
### Motivation

- Reduce CI noise and avoid expensive installs/tests in PRs by skipping heavy steps and providing explicit PR-mode notes.  
- Add dedicated workflows for Python unit tests and subgraph build so these tasks are run in the proper push context.  
- Remove embedded sensitive test keys and make the `direct_l3` Hardhat network configurable from environment variables.  
- Make dependency resolution more deterministic by declaring `graphql`/`rxjs` and adding a lint script to the package manifest.  

### Description

- Updated multiple GitHub Actions workflows to add `if: github.event_name == 'push'` guards for install/compile/test steps, add PR-note steps, and include `merge_group` where appropriate.  
- Added `python-unit-tests.yml` and `subgraph-build.yml` to run Python unit discovery and subgraph codegen/build on push events.  
- Modified `slither.yml`, `verify-and-report.yml`, and other workflows to be push-gated (removed `pull_request` triggers) and tightened reporting messages.  
- Updated `hardhat.config.js` to `import "dotenv/config"` and source `DIRECT_L3_RPC_URL` and `DIRECT_L3_PRIVATE_KEY` from the environment instead of embedding a private key.  
- Updated `package.json` to add a `lint` script, declare `graphql` and `rxjs` dependencies, and ensure `@graphprotocol/graph-cli` is available in devDependencies.  
- Documentation updates in `README.md` and `CONTRIBUTING.md` to document CI/PR hygiene and npm troubleshooting guidance.  

### Testing

- No automated GitHub Actions jobs were executed by this PR because the workflows are now gated to run full suites only on `push` events.  
- CI YAML changes were reviewed for syntax and workflow intent, but no runtime CI job outputs are included in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4b073c2588329b0eb7bd0a5a6fc41)