### PR TITLE
Add guarded Base Sepolia full-suite pipeline

### DIFF
--- a/.github/workflows/base-sepolia-pipeline.yml
+++ b/.github/workflows/base-sepolia-pipeline.yml
@@ -1,0 +1,80 @@
+name: Sentinel L3 Base Sepolia Pipeline
+
+on:
+  workflow_dispatch:
+    inputs:
+      broadcast:
+        description: 'Deploy the full suite after readiness checks'
+        required: true
+        default: false
+        type: boolean
+      confirmation:
+        description: 'Type DEPLOY_BASE_SEPOLIA to authorize broadcast'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sentinel-l3-base-sepolia
+  cancel-in-progress: false
+
+jobs:
+  readiness:
+    runs-on: ubuntu-latest
+    environment: base-sepolia
+    env:
+      DEPLOY_NETWORK: base-sepolia
+      BASE_TESTNET_RPC_URL: ${{ secrets.BASE_TESTNET_RPC_URL }}
+      OWNER_PRIVATE_KEY: ${{ secrets.OWNER_PRIVATE_KEY }}
+      DEPLOYER_PRIVATE_KEY: ${{ secrets.OWNER_PRIVATE_KEY }}
+      SENTINEL_OWNER: ${{ secrets.OWNER_ADDRESS }}
+      RELAYER_ADDRESSES: ${{ secrets.RELAYER_ADDRESSES }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+      - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+      - run: npm ci --legacy-peer-deps
+      - run: forge build --sizes
+      - run: forge test -vvv
+      - name: Validate Base Sepolia RPC, signer, balance, and configuration
+        run: node scripts/mainnet-preflight.js
+
+  deploy:
+    needs: readiness
+    if: ${{ inputs.broadcast && inputs.confirmation == 'DEPLOY_BASE_SEPOLIA' }}
+    runs-on: ubuntu-latest
+    environment: base-sepolia
+    env:
+      BASE_TESTNET_RPC_URL: ${{ secrets.BASE_TESTNET_RPC_URL }}
+      OWNER_PRIVATE_KEY: ${{ secrets.OWNER_PRIVATE_KEY }}
+      DEPLOYER_PRIVATE_KEY: ${{ secrets.OWNER_PRIVATE_KEY }}
+      SENTINEL_OWNER: ${{ secrets.OWNER_ADDRESS }}
+      RELAYER_ADDRESSES: ${{ secrets.RELAYER_ADDRESSES }}
+      TRACKED_CHAIN_IDS: '84532'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci --legacy-peer-deps
+      - name: Compile contracts
+        run: npm run compile
+      - name: Deploy full 27-contract suite to Base Sepolia
+        run: npm run deploy:base-sepolia | tee base-sepolia-deployment.log
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: base-sepolia-deployment-${{ github.run_id }}
+          path: base-sepolia-deployment.log
+          if-no-files-found: error
+

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -110,4 +110,3 @@ const config = {
 };
 
 export default config;
-

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -46,11 +46,13 @@ const config = {
             type: 'http',
             url: process.env.BASE_TESTNET_RPC_URL,
             accounts: [DEPLOYER_PRIVATE_KEY],
+            chainId: 84532,
           },
           baseSepoliaBridge: {
             type: 'http',
             url: process.env.BASE_TESTNET_RPC_URL,
             accounts: [BRIDGE_PRIVATE_KEY],
+            chainId: 84532,
           },
         }
       : {}),
@@ -108,3 +110,4 @@ const config = {
 };
 
 export default config;
+

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "deploy:local": "hardhat run scripts/deploy.js --network direct_l3",
     "deploy:testnet": "hardhat run scripts/deploy.js --network sepolia",
     "deploy:sepolia": "hardhat run scripts/deploy.js --network sepolia",
+    "deploy:base-sepolia": "hardhat run scripts/deploy.cjs --network baseSepolia",
+    "preflight:base-sepolia": "node scripts/mainnet-preflight.js",
     "deploy:mainnet": "node orchestrator.cjs --network mainnet",
     "deploy:polygon": "node node_modules/hardhat/dist/src/cli.js run scripts/deploy.js --network polygon",
     "deploy:base": "node orchestrator.cjs --network base",
@@ -147,3 +149,4 @@
     "@ethersproject/wordlists": "^5.8.0"
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -149,4 +149,3 @@
     "@ethersproject/wordlists": "^5.8.0"
   }
 }
-

--- a/scripts/mainnet-preflight.js
+++ b/scripts/mainnet-preflight.js
@@ -28,6 +28,7 @@ function reqAddrList(name, vals, req = false) {
 const NETWORKS = {
   mainnet: { rpcEnv: 'MAINNET_RPC_URL', chainId: 1, name: 'mainnet', currency: 'ETH' },
   base: { rpcEnv: 'BASE_MAINNET_RPC_URL', chainId: 8453, name: 'base', currency: 'ETH' },
+  'base-sepolia': { rpcEnv: 'BASE_TESTNET_RPC_URL', chainId: 84532, name: 'base-sepolia', currency: 'ETH' },
 };
 
 async function main() {
@@ -98,7 +99,7 @@ async function main() {
 
   if (balance === 0n) throw new Error(`Deployer ${deployerAddress} has zero ${network.currency} on ${network.name}`);
 
-  console.log('MAINNET PREFLIGHT: PASS');
+  console.log('DEPLOYMENT PREFLIGHT: PASS');
   console.log('Network:', network.name, `(chainId ${network.chainId})`);
   console.log('Latest block:', blockNumber);
   console.log('Deployer:', deployerAddress);
@@ -109,4 +110,5 @@ async function main() {
   console.log('\nNo transactions sent. All config valid.');
 }
 
-main().catch(e => { console.error('MAINNET PREFLIGHT: FAIL'); console.error(e.message); process.exitCode = 1; });
+main().catch(e => { console.error('DEPLOYMENT PREFLIGHT: FAIL'); console.error(e.message); process.exitCode = 1; });
+

--- a/scripts/mainnet-preflight.js
+++ b/scripts/mainnet-preflight.js
@@ -111,4 +111,3 @@ async function main() {
 }
 
 main().catch(e => { console.error('DEPLOYMENT PREFLIGHT: FAIL'); console.error(e.message); process.exitCode = 1; });
-


### PR DESCRIPTION
## Summary

- Configure Hardhat Base Sepolia networks with chain ID 84532.
- Add a full 27-contract Base Sepolia deployment command.
- Extend deployment preflight to validate Base Sepolia RPC chain ID, signer, balance, owner, relayers, and gas data.
- Add a manual GitHub Actions pipeline that runs readiness checks by default and only broadcasts after an explicit checkbox, exact confirmation phrase, and `base-sepolia` environment approval.

## Safety

The workflow does not broadcast by default. Deployment requires `broadcast=true`, confirmation `DEPLOY_BASE_SEPOLIA`, valid environment secrets, and approval of the protected `base-sepolia` environment.

## Validation

- `npm test` — 385/385 tests passed locally.
- No RPC credentials or private keys were read or committed.
- No transaction was signed or broadcast.

## Required repository configuration

Create/protect the `base-sepolia` environment and configure `BASE_TESTNET_RPC_URL`, `OWNER_PRIVATE_KEY`, `OWNER_ADDRESS`, and `RELAYER_ADDRESSES` before running readiness mode.