### PR TITLE
Reuse existing deployer secret for Base Sepolia readiness

### DIFF
--- a/.github/workflows/base-sepolia-pipeline.yml
+++ b/.github/workflows/base-sepolia-pipeline.yml
@@ -27,8 +27,8 @@ jobs:
     env:
       DEPLOY_NETWORK: base-sepolia
       BASE_TESTNET_RPC_URL: ${{ secrets.BASE_TESTNET_RPC_URL }}
-      OWNER_PRIVATE_KEY: ${{ secrets.OWNER_PRIVATE_KEY }}
-      DEPLOYER_PRIVATE_KEY: ${{ secrets.OWNER_PRIVATE_KEY }}
+      OWNER_PRIVATE_KEY: ${{ secrets.OWNER_PRIVATE_KEY || secrets.DEPLOYER_PRIVATE_KEY }}
+      DEPLOYER_PRIVATE_KEY: ${{ secrets.OWNER_PRIVATE_KEY || secrets.DEPLOYER_PRIVATE_KEY }}
       SENTINEL_OWNER: ${{ secrets.OWNER_ADDRESS }}
       RELAYER_ADDRESSES: ${{ secrets.RELAYER_ADDRESSES }}
     steps:
@@ -55,8 +55,8 @@ jobs:
     environment: base-sepolia
     env:
       BASE_TESTNET_RPC_URL: ${{ secrets.BASE_TESTNET_RPC_URL }}
-      OWNER_PRIVATE_KEY: ${{ secrets.OWNER_PRIVATE_KEY }}
-      DEPLOYER_PRIVATE_KEY: ${{ secrets.OWNER_PRIVATE_KEY }}
+      OWNER_PRIVATE_KEY: ${{ secrets.OWNER_PRIVATE_KEY || secrets.DEPLOYER_PRIVATE_KEY }}
+      DEPLOYER_PRIVATE_KEY: ${{ secrets.OWNER_PRIVATE_KEY || secrets.DEPLOYER_PRIVATE_KEY }}
       SENTINEL_OWNER: ${{ secrets.OWNER_ADDRESS }}
       RELAYER_ADDRESSES: ${{ secrets.RELAYER_ADDRESSES }}
       TRACKED_CHAIN_IDS: '84532'


### PR DESCRIPTION
## Summary

- Reuse `OWNER_PRIVATE_KEY` when present and otherwise fall back to the repository's existing `DEPLOYER_PRIVATE_KEY` secret.
- Apply the same mapping to readiness and the separately guarded deployment job.
- Avoid exposing or duplicating encrypted key material that GitHub cannot copy across repositories.

## Safety

The deployment job remains disabled unless `broadcast` is enabled and the exact confirmation phrase is supplied. This change does not broadcast transactions.

## Validation

Not run locally. Required GitHub Actions checks validate the workflow change. After merge, the readiness-only workflow will verify the signer, Base Sepolia RPC, balance, and configuration without sending transactions.