### PR TITLE
Fix Base Sepolia deployer key propagation

### DIFF
--- a/.github/workflows/base-sepolia-pipeline.yml
+++ b/.github/workflows/base-sepolia-pipeline.yml
@@ -80,7 +80,10 @@ jobs:
       - name: Compile contracts
         run: npm run compile
       - name: Deploy full 27-contract suite to Base Sepolia
-        run: npm run deploy:base-sepolia | tee base-sepolia-deployment.log
+        shell: bash
+        run: |
+          set -o pipefail
+          npm run deploy:base-sepolia | tee base-sepolia-deployment.log
       - name: Extract deployment manifest
         if: success()
         run: |

--- a/scripts/deploy.cjs
+++ b/scripts/deploy.cjs
@@ -88,7 +88,7 @@ async function getTxOverrides(provider) {
 }
 
 function requireOwnerPrivateKey() {
-  const privateKey = (process.env.OWNER_PRIVATE_KEY || '').trim();
+  const privateKey = (shellOwnerKey || process.env.OWNER_PRIVATE_KEY || '').trim();
   if (!/^0x[0-9a-fA-F]{64}$/.test(privateKey)) {
     throw new Error(
       requestedNetwork === 'mainnet'


### PR DESCRIPTION
## Summary
Fix the Base Sepolia deployment failure observed in workflow run #29864189448 without rerunning or duplicating any on-chain deployment.

## What changed
- preserve the CI-provided owner/deployer key captured before Hardhat and dotenv configuration load
- enable `pipefail` for the deployment log pipeline so an npm deployment failure fails the deployment step immediately

## Validation
The preceding readiness job passed on Base Sepolia. Deployment run #29864189448 stopped before wallet creation with `OWNER_PRIVATE_KEY environment variable must be set`; no transaction was broadcast. CI validation is pending on this PR.

Refs #169.