### PR TITLE
Normalize quoted Base Sepolia deployer key

### DIFF
--- a/scripts/deploy.cjs
+++ b/scripts/deploy.cjs
@@ -88,7 +88,9 @@ async function getTxOverrides(provider) {
 }
 
 function requireOwnerPrivateKey() {
-  const privateKey = (shellOwnerKey || process.env.OWNER_PRIVATE_KEY || '').trim();
+  const privateKey = (shellOwnerKey || process.env.OWNER_PRIVATE_KEY || '')
+    .trim()
+    .replace(/^[\"']|[\"']$/g, '');
   if (!/^0x[0-9a-fA-F]{64}$/.test(privateKey)) {
     throw new Error(
       requestedNetwork === 'mainnet'


### PR DESCRIPTION
## Summary
Normalize the Base Sepolia deployer key exactly as the successful readiness validator already does.

## What changed
- trim whitespace and remove one surrounding quote pair from the CI-provided owner/deployer key before strict 0x + 64-hex validation

## Validation
Not run locally. Base Sepolia readiness passed with the configured key. Runs #29864189448 and #29865699009 both stopped before wallet creation and broadcast no transactions. The latter confirmed failure propagation works correctly.

Refs #169.