### PR TITLE
Fix Base Sepolia deploy key selection

### DIFF
--- a/scripts/deploy.cjs
+++ b/scripts/deploy.cjs
@@ -2,7 +2,28 @@ console.log('=== DEPLOY SCRIPT START ===');
 let hre;
 let ethers;
 let deployer; // Will be set in main()
-const shellOwnerKey = process.env.CI_OWNER_PRIVATE_KEY || process.env.OWNER_PRIVATE_KEY;
+const shellOwnerKeyCandidates = [
+  ['OWNER_PRIVATE_KEY', process.env.OWNER_PRIVATE_KEY],
+  ['DEPLOYER_PRIVATE_KEY', process.env.DEPLOYER_PRIVATE_KEY],
+  ['CI_OWNER_PRIVATE_KEY', process.env.CI_OWNER_PRIVATE_KEY],
+];
+
+function normalizePrivateKey(value) {
+  let normalized = String(value || '').trim().replace(/^\uFEFF/, '');
+  while (
+    normalized.length >= 2 &&
+    ((normalized.startsWith('"') && normalized.endsWith('"')) ||
+      (normalized.startsWith("'") && normalized.endsWith("'")))
+  ) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+  if (/^[0-9a-fA-F]{64}$/.test(normalized)) normalized = `0x${normalized}`;
+  return normalized;
+}
+
+const shellOwnerKey = shellOwnerKeyCandidates
+  .map(([, value]) => normalizePrivateKey(value))
+  .find(value => /^0x[0-9a-fA-F]{64}$/.test(value));
 const networkArgIndex = process.argv.indexOf('--network');
 const requestedNetwork =
   process.env.HARDHAT_NETWORK ||
@@ -88,14 +109,20 @@ async function getTxOverrides(provider) {
 }
 
 function requireOwnerPrivateKey() {
-  const privateKey = (shellOwnerKey || process.env.OWNER_PRIVATE_KEY || '')
-    .trim()
-    .replace(/^[\"']|[\"']$/g, '');
+  const privateKey =
+    shellOwnerKey || normalizePrivateKey(process.env.OWNER_PRIVATE_KEY);
   if (!/^0x[0-9a-fA-F]{64}$/.test(privateKey)) {
+    const diagnostics = shellOwnerKeyCandidates
+      .map(([name, value]) => {
+        const normalized = normalizePrivateKey(value);
+        return `${name}:${value === undefined ? 'missing' : `invalid(length=${normalized.length})`}`;
+      })
+      .join(', ');
     throw new Error(
-      requestedNetwork === 'mainnet'
-        ? 'Mainnet deploy requires OWNER_PRIVATE_KEY in the shell as a 0x-prefixed 32-byte hex key. It is intentionally not read from .env.mainnet.'
-        : 'OWNER_PRIVATE_KEY environment variable must be set as a 0x-prefixed 32-byte hex key.'
+      (requestedNetwork === 'mainnet'
+        ? 'Mainnet deploy requires a valid shell private key. It is intentionally not read from .env.mainnet.'
+        : 'Deployment requires a 32-byte hexadecimal private key.') +
+        ` Candidate status: ${diagnostics}`
     );
   }
   return privateKey;


### PR DESCRIPTION
## Summary
- normalize nested quotes, whitespace, and BOMs in deployment key values
- accept canonical 32-byte hex keys with or without an explicit `0x` prefix
- validate each configured key candidate instead of trusting the first non-empty value
- keep failure diagnostics secret-safe by reporting only presence and normalized length

## Why
Guarded Base Sepolia run #9 cleared readiness, but `scripts/deploy.cjs` rejected the key before wallet construction. The deploy script previously preferred `CI_OWNER_PRIVATE_KEY` without validating fallback candidates.

## Testing
- Not run locally; repository GitHub Actions are the validation source for this connector-authored change.
- No deployment is triggered by this PR.

Refs #169
Run: https://github.com/MastaTrill/Aetheron-Sentinel-L3/actions/runs/29870452674