### PR TITLE
fix: unblock Base Sepolia readiness without weakening broadcast gate

### DIFF
--- a/.github/workflows/base-sepolia-pipeline.yml
+++ b/.github/workflows/base-sepolia-pipeline.yml
@@ -42,6 +42,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+      - name: Initialize readiness evidence
+        run: |
+          mkdir -p artifacts/base-sepolia-readiness
+          : > artifacts/base-sepolia-readiness/base-sepolia-readiness.log
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -50,9 +54,10 @@ jobs:
         with:
           version: v1.7.1
       - run: npm ci --legacy-peer-deps
-      - name: Require protected deployment environment
+      - name: Validate deployment environment
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          REQUIRE_DEPLOYMENT_REVIEWERS: ${{ inputs.broadcast }}
         run: npm run security:deployment-environment
       - name: Validate frozen release scope
         run: npm run security:release-scope
@@ -72,17 +77,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm run preflight:base-sepolia | tee base-sepolia-readiness.log
+          npm run preflight:base-sepolia | tee artifacts/base-sepolia-readiness/base-sepolia-readiness.log
       - name: Simulate the exact deployment script
-        run: npm run mainnet:simulate
+        run: |
+          npm run mainnet:simulate
+          cp /tmp/sentinel-guardrails-simulation.json artifacts/base-sepolia-readiness/
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: base-sepolia-readiness-${{ github.run_id }}
-          path: |
-            base-sepolia-readiness.log
-            /tmp/sentinel-guardrails-simulation.json
-          if-no-files-found: error
+          path: artifacts/base-sepolia-readiness
+          if-no-files-found: warn
 
   deploy:
     needs: readiness

--- a/scripts/lib/github-environment.cjs
+++ b/scripts/lib/github-environment.cjs
@@ -1,7 +1,10 @@
-function assertProtectedEnvironment(environmentName, environment) {
+function assertProtectedEnvironment(environmentName, environment, options = {}) {
+  const requireReviewers = options.requireReviewers !== false;
   const rules = Array.isArray(environment?.protection_rules) ? environment.protection_rules : [];
   const reviewerRule = rules.find(rule => rule.type === 'required_reviewers');
-  if (!reviewerRule || !Array.isArray(reviewerRule.reviewers) || reviewerRule.reviewers.length === 0) {
+  const reviewerCount = Array.isArray(reviewerRule?.reviewers) ? reviewerRule.reviewers.length : 0;
+
+  if (requireReviewers && reviewerCount === 0) {
     throw new Error(`${environmentName} must require at least one deployment reviewer`);
   }
 
@@ -12,7 +15,8 @@ function assertProtectedEnvironment(environmentName, environment) {
 
   return {
     environmentName,
-    reviewerCount: reviewerRule.reviewers.length,
+    reviewerCount,
+    requireReviewers,
     branchPolicy,
   };
 }

--- a/scripts/validate-github-environment.cjs
+++ b/scripts/validate-github-environment.cjs
@@ -4,6 +4,8 @@ async function main() {
   const repository = process.env.GITHUB_REPOSITORY;
   const environmentName = process.env.DEPLOY_ENVIRONMENT;
   const token = process.env.GITHUB_TOKEN;
+  const requireReviewers = process.env.REQUIRE_DEPLOYMENT_REVIEWERS !== 'false';
+
   if (!repository || !/^[^/]+\/[^/]+$/.test(repository)) {
     throw new Error('GITHUB_REPOSITORY is missing or invalid');
   }
@@ -26,9 +28,12 @@ async function main() {
     );
   }
 
-  const result = assertProtectedEnvironment(environmentName, await response.json());
+  const result = assertProtectedEnvironment(environmentName, await response.json(), {
+    requireReviewers,
+  });
   console.log('GITHUB ENVIRONMENT: PASS');
   console.log(`Environment: ${result.environmentName}`);
+  console.log(`Deployment reviewer required: ${result.requireReviewers}`);
   console.log(`Required reviewers: ${result.reviewerCount}`);
   console.log(`Deployment branch policy: ${JSON.stringify(result.branchPolicy)}`);
 }

--- a/test/github-environment.test.cjs
+++ b/test/github-environment.test.cjs
@@ -16,9 +16,10 @@ test('accepts an environment with reviewers and protected branches', () => {
     },
   });
   assert.equal(result.reviewerCount, 1);
+  assert.equal(result.requireReviewers, true);
 });
 
-test('rejects an environment without required reviewers', () => {
+test('rejects an environment without required reviewers by default', () => {
   assert.throws(
     () =>
       assertProtectedEnvironment('base-mainnet', {
@@ -32,18 +33,34 @@ test('rejects an environment without required reviewers', () => {
   );
 });
 
+test('allows a readiness-only environment without reviewers', () => {
+  const result = assertProtectedEnvironment(
+    'base-sepolia',
+    {
+      protection_rules: [],
+      deployment_branch_policy: {
+        protected_branches: false,
+        custom_branch_policies: true,
+      },
+    },
+    { requireReviewers: false }
+  );
+
+  assert.equal(result.reviewerCount, 0);
+  assert.equal(result.requireReviewers, false);
+});
+
 test('rejects an environment without a branch restriction', () => {
   assert.throws(
     () =>
-      assertProtectedEnvironment('base-mainnet', {
-        protection_rules: [
-          {
-            type: 'required_reviewers',
-            reviewers: [{ type: 'User', reviewer: { login: 'security-reviewer' } }],
-          },
-        ],
-        deployment_branch_policy: null,
-      }),
+      assertProtectedEnvironment(
+        'base-sepolia',
+        {
+          protection_rules: [],
+          deployment_branch_policy: null,
+        },
+        { requireReviewers: false }
+      ),
     /restrict deployment branches/
   );
 });


### PR DESCRIPTION
## Summary
Unblock non-broadcast Base Sepolia readiness without weakening the guarded deployment gate.

## What changed
- readiness-only runs no longer require a deployment reviewer
- guarded broadcast runs still require at least one deployment reviewer
- deployment branch restrictions remain mandatory for both modes
- readiness evidence is initialized early so an upstream failure does not create a second artifact error
- focused tests cover readiness-only and guarded validation behavior

## Why
The current `broadcast: false` readiness run stopped before RPC, signer, balance, tests, or simulation because the environment had no reviewer. Reviewer approval is a broadcast protection, not a prerequisite for a non-broadcast diagnostic run.

## Safety
This does not authorize a transaction. `broadcast: true` still requires the exact `DEPLOY_BASE_SEPOLIA` confirmation and the reviewer check remains enforced for that mode. Contracts remain paused and non-custodial.

## Validation
```bash
node --test test/github-environment.test.cjs
```

Focused result: 4 tests passed locally. Branch CI must pass before merge.

Tracks #169.