### PR TITLE
fix: preserve partial Base Sepolia simulation evidence

### DIFF
--- a/.github/workflows/base-sepolia-pipeline.yml
+++ b/.github/workflows/base-sepolia-pipeline.yml
@@ -79,9 +79,13 @@ jobs:
           set -euo pipefail
           npm run preflight:base-sepolia | tee artifacts/base-sepolia-readiness/base-sepolia-readiness.log
       - name: Simulate the exact deployment script
+        run: npm run mainnet:simulate
+      - name: Collect simulation evidence
+        if: always()
         run: |
-          npm run mainnet:simulate
-          cp /tmp/sentinel-guardrails-simulation.json artifacts/base-sepolia-readiness/
+          if [ -f /tmp/sentinel-guardrails-simulation.json ]; then
+            cp /tmp/sentinel-guardrails-simulation.json artifacts/base-sepolia-readiness/
+          fi
       - uses: actions/upload-artifact@v4
         if: always()
         with:


### PR DESCRIPTION
## Summary
Preserve the partial simulation manifest even when the Base Sepolia readiness simulation fails.

## What changed
- moved manifest collection into a separate `if: always()` step
- retained the dedicated readiness artifact directory
- kept readiness non-broadcasting and the guarded broadcast controls unchanged

## Validation
```bash
node --test test/github-environment.test.cjs
```

The prior focused tests passed, and branch CI must pass before merge.

Follow-up to #182 and tracks #169.