### PR TITLE
ci: add owner-only Sentinel readiness command

### DIFF
--- a/.github/workflows/sentinel-readiness-command.yml
+++ b/.github/workflows/sentinel-readiness-command.yml
@@ -1,0 +1,150 @@
+name: Sentinel Readiness Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  deployments: read
+  issues: write
+
+concurrency:
+  group: sentinel-readiness-command
+  cancel-in-progress: false
+
+jobs:
+  readiness:
+    if: >-
+      github.event.issue.number == 169 &&
+      github.event.issue.pull_request == null &&
+      github.event.comment.body == '/sentinel-readiness' &&
+      github.actor == github.repository_owner
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: base-sepolia
+    env:
+      RELEASE_PROFILE: sentinel-guardrails-v1
+      DEPLOY_NETWORK: base-sepolia
+      DEPLOY_ENVIRONMENT: base-sepolia
+      BASE_TESTNET_RPC_URL: ${{ secrets.BASE_TESTNET_RPC_URL }}
+      DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
+      SENTINEL_OWNER: ${{ secrets.OWNER_ADDRESS }}
+      MONITOR_ADDRESSES: ${{ secrets.MONITOR_ADDRESSES }}
+      MIN_DEPLOYER_BALANCE_ETH: '0.05'
+      RELEASE_COMMIT: a2e61a646129bc5744e6f5f734823fb5604b58e5
+      DEPLOYMENT_MANIFEST_PATH: deployments/baseSepolia-sentinel-guardrails-v1.json
+    steps:
+      - name: Checkout isolated release candidate
+        uses: actions/checkout@v6
+        with:
+          ref: a2e61a646129bc5744e6f5f734823fb5604b58e5
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Initialize readiness evidence
+        run: |
+          mkdir -p artifacts/base-sepolia-readiness
+          : > artifacts/base-sepolia-readiness/base-sepolia-readiness.log
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Setup Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.1
+
+      - name: Install dependencies
+        id: dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Validate deployment environment
+        id: environment
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REQUIRE_DEPLOYMENT_REVIEWERS: 'false'
+        run: npm run security:deployment-environment
+
+      - name: Validate frozen release scope
+        id: scope
+        run: npm run security:release-scope
+
+      - name: Audit release and toolchain dependencies
+        id: audit
+        run: |
+          npm run security:audit
+          npm run security:audit:toolchain
+
+      - name: Compile exact deployment artifacts
+        id: compile
+        run: npm run compile
+
+      - name: Run release regression tests
+        id: release_tests
+        run: npm run test:release
+
+      - name: Run Foundry build and tests
+        id: foundry
+        run: |
+          forge build --sizes
+          forge test -vvv
+
+      - name: Validate RPC, signer, owner, balance, and monitors
+        id: preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run preflight:base-sepolia | tee artifacts/base-sepolia-readiness/base-sepolia-readiness.log
+
+      - name: Simulate exact deployment
+        id: simulation
+        run: npm run mainnet:simulate
+
+      - name: Collect simulation evidence
+        if: always()
+        run: |
+          if [ -f /tmp/sentinel-guardrails-simulation.json ]; then
+            cp /tmp/sentinel-guardrails-simulation.json artifacts/base-sepolia-readiness/
+          fi
+
+      - name: Upload readiness evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: base-sepolia-readiness-${{ github.run_id }}
+          path: artifacts/base-sepolia-readiness
+          if-no-files-found: warn
+
+      - name: Report result to launch gate
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          cat > /tmp/sentinel-readiness-report.md <<'EOF'
+          ## Automated Base Sepolia readiness result
+
+          - **Overall:** `${{ job.status }}`
+          - **Release candidate:** `a2e61a646129bc5744e6f5f734823fb5604b58e5`
+          - **Workflow run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          - **Broadcast:** disabled; this workflow cannot send a deployment transaction
+
+          | Gate | Outcome |
+          |---|---|
+          | Dependencies | `${{ steps.dependencies.outcome }}` |
+          | Environment | `${{ steps.environment.outcome }}` |
+          | Release scope | `${{ steps.scope.outcome }}` |
+          | Audits | `${{ steps.audit.outcome }}` |
+          | Compile | `${{ steps.compile.outcome }}` |
+          | Release tests | `${{ steps.release_tests.outcome }}` |
+          | Foundry | `${{ steps.foundry.outcome }}` |
+          | RPC / signer / balance / governance | `${{ steps.preflight.outcome }}` |
+          | Exact simulation | `${{ steps.simulation.outcome }}` |
+
+          The readiness artifact is attached to the workflow run when available.
+          EOF
+          gh issue comment 169 --repo "$GITHUB_REPOSITORY" --body-file /tmp/sentinel-readiness-report.md


### PR DESCRIPTION
## Summary
Add an owner-only `/sentinel-readiness` issue command that runs the complete non-broadcast Base Sepolia readiness suite and reports the result to launch-gate issue #169.

## Safety
- accepts only an exact command from the repository owner
- runs only on issue #169
- checks out immutable candidate `a2e61a646129bc5744e6f5f734823fb5604b58e5`
- contains no deployment job and cannot broadcast transactions
- uses the protected `base-sepolia` environment for existing secrets

## Release integrity
The candidate starts from frozen commit `190a3d30f25f45a026c32d3ef6ececf4848f6b46` and differs only in four reviewed readiness workflow/validation files. No contract source changed.

## Validation
```bash
node --test test/github-environment.test.cjs
```

Repository CI must pass before merge.

Tracks #169.