### PR TITLE
fix: authorize readiness command before environment access

### DIFF
--- a/.github/workflows/sentinel-readiness-command.yml
+++ b/.github/workflows/sentinel-readiness-command.yml
@@ -14,12 +14,32 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  readiness:
+  authorize:
     if: >-
       github.event.issue.number == 169 &&
-      github.event.issue.pull_request == null &&
-      github.event.comment.body == '/sentinel-readiness' &&
-      github.actor == github.repository_owner
+      github.event.comment.body == '/sentinel-readiness'
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.auth.outputs.allowed }}
+    steps:
+      - name: Authorize repository owner
+        id: auth
+        env:
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${COMMENT_AUTHOR,,}" = "${REPOSITORY_OWNER,,}" ]; then
+            echo 'allowed=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'allowed=false' >> "$GITHUB_OUTPUT"
+            echo "Ignoring readiness command from unauthorized account: $COMMENT_AUTHOR"
+          fi
+
+  readiness:
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: base-sepolia


### PR DESCRIPTION
## Summary
Fix the owner-only Sentinel readiness trigger so authorization happens in a separate job before the protected `base-sepolia` environment and its secrets are loaded.

## Safety
- command still requires exact `/sentinel-readiness` on issue #169
- comment author is compared case-insensitively with the repository owner
- unauthorized commands never enter the environment-backed readiness job
- release candidate remains pinned to immutable SHA `a2e61a646129bc5744e6f5f734823fb5604b58e5`
- no deployment or transaction step exists

## Validation
```bash
node --test test/github-environment.test.cjs
```

The focused validation passed on the isolated candidate. Repository CI must pass before merge.

Tracks #169.