### PR TITLE
fix: start isolated Sentinel readiness on merge

### DIFF
--- a/.github/workflows/sentinel-readiness-command.yml
+++ b/.github/workflows/sentinel-readiness-command.yml
@@ -1,6 +1,10 @@
 name: Sentinel Readiness Command
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/sentinel-readiness-command.yml'
   issue_comment:
     types: [created]
 
@@ -16,21 +20,25 @@ concurrency:
 jobs:
   authorize:
     if: >-
-      github.event.issue.number == 169 &&
-      github.event.comment.body == '/sentinel-readiness'
+      github.event_name == 'push' ||
+      (github.event.issue.number == 169 &&
+       github.event.comment.body == '/sentinel-readiness')
     runs-on: ubuntu-latest
     outputs:
       allowed: ${{ steps.auth.outputs.allowed }}
     steps:
-      - name: Authorize repository owner
+      - name: Authorize trusted trigger
         id: auth
         env:
+          EVENT_NAME: ${{ github.event_name }}
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${COMMENT_AUTHOR,,}" = "${REPOSITORY_OWNER,,}" ]; then
+          if [ "$EVENT_NAME" = 'push' ]; then
+            echo 'allowed=true' >> "$GITHUB_OUTPUT"
+          elif [ "${COMMENT_AUTHOR,,}" = "${REPOSITORY_OWNER,,}" ]; then
             echo 'allowed=true' >> "$GITHUB_OUTPUT"
           else
             echo 'allowed=false' >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
Start the isolated non-broadcast Sentinel readiness suite automatically when this workflow file is merged to `main`.

## Why
GitHub suppresses the connector-created issue comment from starting Actions. A path-limited `push` trigger avoids that limitation and runs exactly once when this workflow change reaches `main`.

## Safety
- push trigger is limited to `main` and this single workflow path
- readiness checks out immutable candidate `a2e61a646129bc5744e6f5f734823fb5604b58e5`
- no contract source is taken from current `main`
- no deployment job or broadcast command exists
- the issue-comment owner authorization remains available for normal user-created comments

## Validation
```bash
node --test test/github-environment.test.cjs
```

Repository CI must pass before merge.

Tracks #169.