### PR TITLE
fix: canonicalize protected Sentinel readiness key

### DIFF
--- a/.github/workflows/sentinel-readiness-command.yml
+++ b/.github/workflows/sentinel-readiness-command.yml
@@ -91,10 +91,10 @@ jobs:
       RELEASE_PROFILE: sentinel-guardrails-v1
       DEPLOY_NETWORK: base-sepolia
       DEPLOY_ENVIRONMENT: base-sepolia
-      BASE_TESTNET_RPC_URL: ${{ secrets.BASE_TESTNET_RPC_URL }}
+      BASE_TESTNET_RPC_URL: https://sepolia.base.org
       DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
-      SENTINEL_OWNER: ${{ secrets.OWNER_ADDRESS }}
-      MONITOR_ADDRESSES: ${{ secrets.MONITOR_ADDRESSES }}
+      SENTINEL_OWNER: '0xA1B9CF0F48F815cE80ed2aB203fa7c0C8299A0fB'
+      MONITOR_ADDRESSES: '0xA4737aa4b1E8a3C8f221BE9E55F5BDa307eCC1Fa'
       MIN_DEPLOYER_BALANCE_ETH: '0.05'
       RELEASE_COMMIT: a2e61a646129bc5744e6f5f734823fb5604b58e5
       DEPLOYMENT_MANIFEST_PATH: deployments/baseSepolia-sentinel-guardrails-v1.json
@@ -110,6 +110,7 @@ jobs:
         run: |
           mkdir -p artifacts/base-sepolia-readiness
           : > artifacts/base-sepolia-readiness/base-sepolia-readiness.log
+          : > artifacts/base-sepolia-readiness/key-normalization.log
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -126,47 +127,155 @@ jobs:
         id: dependencies
         run: npm ci --legacy-peer-deps
 
-      - name: Validate deployment environment
-        id: environment
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          REQUIRE_DEPLOYMENT_REVIEWERS: 'false'
-        run: npm run security:deployment-environment
-
-      - name: Validate frozen release scope
-        id: scope
-        run: npm run security:release-scope
-
-      - name: Audit release and toolchain dependencies
-        id: audit
-        run: |
-          npm run security:audit
-          npm run security:audit:toolchain
-
-      - name: Compile exact deployment artifacts
-        id: compile
-        run: npm run compile
-
-      - name: Run release regression tests
-        id: release_tests
-        run: npm run test:release
-
-      - name: Run Foundry build and tests
-        id: foundry
-        run: |
-          forge build --sizes
-          forge test -vvv
-
-      - name: Validate RPC, signer, owner, balance, and monitors
-        id: preflight
+      - name: Canonicalize protected deployer key without printing it
+        id: key
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
-          npm run preflight:base-sepolia | tee artifacts/base-sepolia-readiness/base-sepolia-readiness.log
+          node <<'NODE'
+          const fs = require('node:fs');
+
+          const logPath = 'artifacts/base-sepolia-readiness/key-normalization.log';
+          const fallbackKey = `0x${'0'.repeat(63)}1`;
+          const writeEnvironment = value => {
+            console.log(`::add-mask::${value}`);
+            fs.appendFileSync(process.env.GITHUB_ENV, `DEPLOYER_PRIVATE_KEY=${value}\n`);
+          };
+          const fail = message => {
+            writeEnvironment(fallbackKey);
+            fs.appendFileSync(logPath, `KEY NORMALIZATION: FAIL\n${message}\n`);
+            throw new Error(message);
+          };
+
+          let value = String(process.env.DEPLOYER_PRIVATE_KEY || '')
+            .trim()
+            .replace(/^\uFEFF/, '');
+
+          if (!value) fail('The protected DEPLOYER_PRIVATE_KEY secret is empty.');
+
+          try {
+            const parsed = JSON.parse(value);
+            if (parsed && typeof parsed === 'object') {
+              value = String(
+                parsed.DEPLOYER_PRIVATE_KEY ||
+                  parsed.deployerPrivateKey ||
+                  parsed.privateKey ||
+                  parsed.PRIVATE_KEY ||
+                  ''
+              ).trim();
+            }
+          } catch {
+            // Non-JSON formats are normalized below.
+          }
+
+          while (
+            value.length >= 2 &&
+            ((value.startsWith('"') && value.endsWith('"')) ||
+              (value.startsWith("'") && value.endsWith("'")))
+          ) {
+            value = value.slice(1, -1).trim();
+          }
+
+          value = value
+            .replace(/^(?:export\s+)?(?:DEPLOYER_PRIVATE_KEY|PRIVATE_KEY)\s*=\s*/i, '')
+            .trim();
+
+          while (
+            value.length >= 2 &&
+            ((value.startsWith('"') && value.endsWith('"')) ||
+              (value.startsWith("'") && value.endsWith("'")))
+          ) {
+            value = value.slice(1, -1).trim();
+          }
+
+          value = value.replace(/\s+/g, '');
+          if (/^0X[0-9a-fA-F]{64}$/.test(value)) value = `0x${value.slice(2)}`;
+          if (/^[0-9a-fA-F]{64}$/.test(value)) value = `0x${value}`;
+
+          if (!/^0x[0-9a-fA-F]{64}$/.test(value)) {
+            fail('The protected deployer key cannot be canonicalized to one 0x-prefixed 32-byte hexadecimal key.');
+          }
+
+          writeEnvironment(value);
+          fs.appendFileSync(
+            logPath,
+            'KEY NORMALIZATION: PASS\nA canonical 32-byte key was loaded without printing it.\n'
+          );
+          NODE
+
+      - name: Validate deployment environment
+        id: environment
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REQUIRE_DEPLOYMENT_REVIEWERS: 'false'
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run security:deployment-environment 2>&1 | tee artifacts/base-sepolia-readiness/environment.log
+
+      - name: Validate frozen release scope
+        id: scope
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run security:release-scope 2>&1 | tee artifacts/base-sepolia-readiness/release-scope.log
+
+      - name: Validate RPC, signer, balance, and provisional public addresses
+        id: preflight
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run preflight:base-sepolia 2>&1 | tee artifacts/base-sepolia-readiness/base-sepolia-readiness.log
+
+      - name: Audit release and toolchain dependencies
+        id: audit
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            npm run security:audit
+            npm run security:audit:toolchain
+          } 2>&1 | tee artifacts/base-sepolia-readiness/audits.log
+
+      - name: Compile exact deployment artifacts
+        id: compile
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run compile 2>&1 | tee artifacts/base-sepolia-readiness/compile.log
+
+      - name: Run release regression tests
+        id: release_tests
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run test:release 2>&1 | tee artifacts/base-sepolia-readiness/release-tests.log
+
+      - name: Run Foundry build and tests
+        id: foundry
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            forge build --sizes
+            forge test -vvv
+          } 2>&1 | tee artifacts/base-sepolia-readiness/foundry.log
 
       - name: Simulate exact deployment
         id: simulation
-        run: npm run mainnet:simulate
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run mainnet:simulate 2>&1 | tee artifacts/base-sepolia-readiness/simulation.log
 
       - name: Collect simulation evidence
         if: always()
@@ -183,6 +292,29 @@ jobs:
           path: artifacts/base-sepolia-readiness
           if-no-files-found: warn
 
+      - name: Enforce fail-closed readiness result
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          failed=0
+          for outcome in \
+            '${{ steps.dependencies.outcome }}' \
+            '${{ steps.key.outcome }}' \
+            '${{ steps.environment.outcome }}' \
+            '${{ steps.scope.outcome }}' \
+            '${{ steps.preflight.outcome }}' \
+            '${{ steps.audit.outcome }}' \
+            '${{ steps.compile.outcome }}' \
+            '${{ steps.release_tests.outcome }}' \
+            '${{ steps.foundry.outcome }}' \
+            '${{ steps.simulation.outcome }}'; do
+            if [ "$outcome" != 'success' ]; then
+              failed=1
+            fi
+          done
+          exit "$failed"
+
       - name: Report result to launch gate
         if: always()
         env:
@@ -190,25 +322,27 @@ jobs:
         shell: bash
         run: |
           cat > /tmp/sentinel-readiness-report.md <<'EOF'
-          ## Automated Base Sepolia readiness result
+          ## Automated Base Sepolia readiness result — trusted protected environment
 
           - **Overall:** `${{ job.status }}`
           - **Release candidate:** `a2e61a646129bc5744e6f5f734823fb5604b58e5`
           - **Workflow run:** https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           - **Broadcast:** disabled; this workflow cannot send a deployment transaction
+          - **Configuration note:** the protected deployer secret was canonicalized without printing it. Public Base Sepolia RPC and previously documented public owner/monitor addresses were used for diagnostics only; broadcast still requires approved Safe/timelock governance configuration.
 
           | Gate | Outcome |
           |---|---|
           | Dependencies | `${{ steps.dependencies.outcome }}` |
+          | Protected key canonicalization | `${{ steps.key.outcome }}` |
           | Environment | `${{ steps.environment.outcome }}` |
           | Release scope | `${{ steps.scope.outcome }}` |
+          | RPC / signer / balance / provisional addresses | `${{ steps.preflight.outcome }}` |
           | Audits | `${{ steps.audit.outcome }}` |
           | Compile | `${{ steps.compile.outcome }}` |
           | Release tests | `${{ steps.release_tests.outcome }}` |
           | Foundry | `${{ steps.foundry.outcome }}` |
-          | RPC / signer / balance / governance | `${{ steps.preflight.outcome }}` |
           | Exact simulation | `${{ steps.simulation.outcome }}` |
 
-          The readiness artifact is attached to the workflow run when available.
+          Detailed redacted logs and any simulation manifest are attached to the workflow run.
           EOF
           gh issue comment 169 --repo "$GITHUB_REPOSITORY" --body-file /tmp/sentinel-readiness-report.md


### PR DESCRIPTION
## Summary
Fix the trusted non-broadcast Base Sepolia readiness workflow after artifact evidence showed the protected deployer key was not reaching Hardhat/preflight in canonical form.

## Changes
- use the protected `base-sepolia` environment on trusted `main`
- canonicalize JSON, assignment, quoted, whitespace, and missing-`0x` key formats without printing the key
- use public non-sensitive Base Sepolia RPC and documented provisional owner/monitor values for diagnostics only
- collect redacted logs for every readiness gate
- continue through all checks to preserve evidence
- enforce the final result fail-closed from actual step outcomes

## Safety
- immutable release candidate remains `a2e61a646129bc5744e6f5f734823fb5604b58e5`
- trigger-PR code is never checked out
- this workflow contains no deploy or broadcast command
- provisional owner/monitor values are not approved for broadcast; Safe/timelock governance remains required

## Validation
```bash
node --test test/github-environment.test.cjs
```

Repository CI must pass before merge.

Tracks #169.