### PR TITLE
Register and harden canonical SENTINEL token release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 ## 📌 Table of Contents
 
 - [Overview](#overview)
+- [Canonical SENTINEL Token](#canonical-sentinel-token)
 - [🚀 Getting Started](#-getting-started)
 - [🛠 Development](#-development)
 - [🛡️ Security](#-security)
@@ -22,7 +23,7 @@
 
 ## Overview
 
-Aetheron Sentinel L3 is a comprehensive security and automation suite for the $SENT ecosystem. It provides automated liquidity management for concentrated liquidity pools, advanced code analysis for smart contracts, a robust security infrastructure, **and verifiable AI agents for DeFAI (Decentralized Finance + AI) with TEE-protected inference and clear autonomy governance**.
+Aetheron Sentinel L3 is a comprehensive security and automation suite for the SENTINEL ecosystem. It provides automated liquidity management for concentrated liquidity pools, advanced code analysis for smart contracts, a robust security infrastructure, **and verifiable AI agents for DeFAI (Decentralized Finance + AI) with TEE-protected inference and clear autonomy governance**.
 
 ### Key Features
 
@@ -31,6 +32,19 @@ Aetheron Sentinel L3 is a comprehensive security and automation suite for the $S
 - **Security Audits**: Professional manual review of smart contract logic and architecture.
 - **Bug Bounty Program**: Incentivized community-led security research.
 - **Verifiable DeFAI AI Agents**: TEE-secured inference (Phala/Oasis/Intel TDX), attestation flows, policy-enforced autonomy levels (0-3), human-in-the-loop, drift monitoring, and seamless fallback to rule-based L3 security (SentinelInterceptor, CircuitBreaker, quantum guards).
+
+## Canonical SENTINEL Token
+
+The canonical Aetheron Sentinel L3 ecosystem token is deployed on Base Mainnet:
+
+- **Contract:** [`0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3`](https://basescan.org/token/0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3)
+- **Network:** Base Mainnet (`8453`)
+- **On-chain name/symbol:** `SENTINEL` / `SENTINEL`
+- **Deployment manifest:** [`deployments/base-mainnet.json`](deployments/base-mainnet.json)
+- **Security and governance plan:** [`docs/SENTINEL_TOKEN_MAINNET.md`](docs/SENTINEL_TOKEN_MAINNET.md)
+- **Verification:** `BASE_RPC_URL=https://mainnet.base.org bash scripts/verify-canonical-token.sh`
+
+> **Release status:** Canonical, pending governance hardening and launch evidence. The separate `contracts/SentinelToken.sol` design is not the verified source for this deployed address and must not be represented as the live token.
 
 ## 🚀 Getting Started
 
@@ -83,5 +97,5 @@ See the dedicated docs in the Documentation Index for implementation details, in
 
 ---
 
-**Document Version:** 1.1 (DeFAI AI additions)  
-**Last Updated:** July 12, 2026
+**Document Version:** 1.2 (canonical token release controls)  
+**Last Updated:** July 26, 2026

--- a/deployments/base-mainnet.json
+++ b/deployments/base-mainnet.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "network": {
+    "name": "Base Mainnet",
+    "chainId": 8453,
+    "explorer": "https://basescan.org"
+  },
+  "tokens": {
+    "sentinel": {
+      "canonical": true,
+      "address": "0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3",
+      "name": "SENTINEL",
+      "symbol": "SENTINEL",
+      "decimals": 18,
+      "displayedMaxSupply": "100000000000000000000000000000",
+      "implementationName": "DERC20",
+      "proxy": false,
+      "sourceVerified": true,
+      "compiler": "v0.8.26+commit.8a97fa7a",
+      "explorerUrl": "https://basescan.org/token/0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3",
+      "deploymentTx": null,
+      "deployer": null,
+      "owner": null,
+      "pool": null,
+      "poolUnlocked": null,
+      "yearlyMintRateWad": null,
+      "vestingStart": null,
+      "vestingDuration": null,
+      "tokenURI": null,
+      "status": "canonical-pending-governance-hardening",
+      "notes": [
+        "Runtime values marked null must be populated by scripts/verify-canonical-token.sh before production launch.",
+        "The repository contract contracts/SentinelToken.sol is not the source used for this deployed address and must not be represented as such.",
+        "Do not announce public trading, liquidity lock, ownership renunciation, or multisig control until each fact is verified on-chain."
+      ]
+    }
+  }
+}

--- a/docs/SENTINEL_TOKEN_MAINNET.md
+++ b/docs/SENTINEL_TOKEN_MAINNET.md
@@ -1,0 +1,128 @@
+# Canonical SENTINEL Token — Base Mainnet
+
+## Canonical deployment
+
+| Field | Value |
+|---|---|
+| Network | Base Mainnet |
+| Chain ID | `8453` |
+| Contract | `0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3` |
+| Explorer | <https://basescan.org/token/0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3> |
+| On-chain name | `SENTINEL` |
+| On-chain symbol | `SENTINEL` |
+| Decimals | `18` |
+| Verified implementation name | `DERC20` |
+| Proxy | No |
+| Compiler shown by BaseScan | `v0.8.26+commit.8a97fa7a` |
+
+This address is the canonical Sentinel token for the Aetheron Sentinel L3 ecosystem. Integrations must load it from `deployments/base-mainnet.json`; do not duplicate the address in application code.
+
+## Important repository distinction
+
+`contracts/SentinelToken.sol` is a separate, legacy/custom token design. It has different metadata, supply, allocation logic, staking behavior, and mint authority. It is **not** the verified source for the canonical Base deployment above. Until a formal migration decision is approved, it must not be deployed or described as the canonical token.
+
+## Administrative capabilities of the deployed token
+
+The verified ABI exposes the following security-sensitive functions:
+
+- `owner()` and `transferOwnership(address)`
+- `renounceOwnership()`
+- `updateMintRate(uint256)`
+- `mintInflation()`
+- `lockPool(address)` and `unlockPool()`
+- `updateTokenURI(string)`
+
+It also exposes ERC-20 burn, ERC-2612 permit, ERC20Votes delegation/checkpoints, and vesting release functions.
+
+## Production governance policy
+
+### Ownership
+
+Before public liquidity or a presale:
+
+1. The owner must be a Safe multisig, never a single externally owned account.
+2. Recommended minimum policy: 2-of-3 for development, moving to 3-of-5 before material public funds are accepted.
+3. Signers should use separate hardware wallets and should not share seed phrases or devices.
+4. The multisig address and signer policy must be published here and in `deployments/base-mainnet.json`.
+5. Any ownership transfer transaction must be linked in the release evidence.
+
+### Timelock
+
+Owner-controlled changes should be routed through a timelock where compatible. Recommended delay: at least 48 hours for mint-rate, pool, and metadata changes. Emergency actions should be narrowly defined and publicly logged.
+
+### Inflation
+
+- Publish the current `yearlyMintRate()` value.
+- Publish the contract-enforced maximum rate confirmed from verified source.
+- Treat every `mintInflation()` call as a supply event requiring release notes.
+- Never describe the token as fixed-supply while inflation remains enabled.
+- Treasury accounting must reconcile total supply before and after each mint.
+
+### Pool controls and liquidity
+
+- Publish the configured `pool()` address.
+- Confirm `isPoolUnlocked()` before claiming the token is freely tradable.
+- Publish pair assets, DEX, fee tier, pool address, starting reserves, and LP ownership.
+- Do not claim liquidity is locked unless a verifiable lock transaction and unlock date exist.
+- Do not burn LP positions without documenting the permanent consequences.
+- Run a real buy-and-sell test with small amounts before announcing trading.
+
+### Token metadata
+
+The immutable on-chain symbol is `SENTINEL`. Marketing may refer to the token as “Sentinel,” but integrations and listings must use the exact on-chain symbol. Do not advertise `$SENT` as the ticker unless the token is migrated or listing venues explicitly map that alias.
+
+## Required launch evidence
+
+The release is blocked until all rows are complete.
+
+| Evidence | Status | Reference |
+|---|---|---|
+| Canonical deployment manifest | Complete | `deployments/base-mainnet.json` |
+| Source verified on BaseScan | Complete | Explorer contract page |
+| On-chain verification script output | Pending | Attach CI artifact or signed release output |
+| Current owner identified | Pending | Populate manifest |
+| Owner is approved multisig | Pending | Safe URL and transfer transaction |
+| Timelock configured or risk accepted | Pending | Governance record |
+| Current mint rate documented | Pending | Populate manifest |
+| Vesting parameters documented | Pending | Populate manifest |
+| Holder/allocation labels published | Pending | Allocation table |
+| Pool address documented | Pending | Populate manifest |
+| Pool unlocked | Pending | Verification output |
+| Liquidity pair funded | Pending | Pair transaction |
+| LP custody/lock documented | Pending | Lock or multisig custody evidence |
+| Buy/sell smoke test passed | Pending | Transaction hashes |
+| Independent security review | Pending | Audit report |
+| Incident response contacts | Pending | Private runbook reference |
+
+## Verification
+
+Install Foundry and run:
+
+```bash
+BASE_RPC_URL=https://mainnet.base.org bash scripts/verify-canonical-token.sh
+```
+
+Save the complete output as a release artifact. Populate the manifest only from direct on-chain reads and transaction receipts.
+
+## Ownership transaction templates
+
+Read the current owner first. Never broadcast from an address that is not the current owner.
+
+```bash
+TOKEN=0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3
+RPC_URL="$BASE_RPC_URL"
+cast call "$TOKEN" 'owner()(address)' --rpc-url "$RPC_URL"
+```
+
+After creating and verifying the Safe multisig, generate—but review before broadcasting—the ownership transfer calldata:
+
+```bash
+SAFE_ADDRESS=0xYourVerifiedSafe
+cast calldata 'transferOwnership(address)' "$SAFE_ADDRESS"
+```
+
+The transaction must be sent through the current owner's wallet. Do not paste private keys into shell history, repositories, chat, CI variables visible to forks, or deployment logs.
+
+## Security verdict
+
+The deployed token is source-verified and non-proxy, but launch readiness depends on live owner, mint-rate, vesting, pool, liquidity, and holder-distribution state. Until those facts are captured and governance is hardened, its release state is **canonical but not production-approved**.

--- a/scripts/verify-canonical-token.sh
+++ b/scripts/verify-canonical-token.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RPC_URL="${BASE_RPC_URL:-https://mainnet.base.org}"
+TOKEN="${SENTINEL_TOKEN_ADDRESS:-0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3}"
+EXPECTED_CHAIN_ID=8453
+
+command -v cast >/dev/null 2>&1 || {
+  echo "ERROR: Foundry cast is required: https://book.getfoundry.sh/getting-started/installation" >&2
+  exit 1
+}
+
+rpc() {
+  cast call "$TOKEN" "$1" --rpc-url "$RPC_URL"
+}
+
+CHAIN_ID="$(cast chain-id --rpc-url "$RPC_URL")"
+[[ "$CHAIN_ID" == "$EXPECTED_CHAIN_ID" ]] || {
+  echo "ERROR: RPC chain id is $CHAIN_ID; expected $EXPECTED_CHAIN_ID (Base mainnet)." >&2
+  exit 1
+}
+
+CODE="$(cast code "$TOKEN" --rpc-url "$RPC_URL")"
+[[ "$CODE" != "0x" ]] || {
+  echo "ERROR: No bytecode at $TOKEN" >&2
+  exit 1
+}
+
+NAME="$(rpc 'name()(string)')"
+SYMBOL="$(rpc 'symbol()(string)')"
+DECIMALS="$(rpc 'decimals()(uint8)')"
+TOTAL_SUPPLY="$(rpc 'totalSupply()(uint256)')"
+OWNER="$(rpc 'owner()(address)')"
+POOL="$(rpc 'pool()(address)')"
+POOL_UNLOCKED="$(rpc 'isPoolUnlocked()(bool)')"
+MINT_RATE="$(rpc 'yearlyMintRate()(uint256)')"
+LAST_MINT="$(rpc 'lastMintTimestamp()(uint256)')"
+VESTING_START="$(rpc 'vestingStart()(uint256)')"
+VESTING_DURATION="$(rpc 'vestingDuration()(uint256)')"
+VESTED_TOTAL="$(rpc 'vestedTotalAmount()(uint256)')"
+TOKEN_URI="$(rpc 'tokenURI()(string)')"
+BYTECODE_HASH="$(cast keccak "$CODE")"
+
+cat <<EOF
+Canonical SENTINEL token verification
+=====================================
+chainId:          $CHAIN_ID
+address:          $TOKEN
+name:             $NAME
+symbol:           $SYMBOL
+decimals:         $DECIMALS
+totalSupply:      $TOTAL_SUPPLY
+owner:            $OWNER
+pool:             $POOL
+poolUnlocked:     $POOL_UNLOCKED
+yearlyMintRate:   $MINT_RATE
+lastMintTimestamp:$LAST_MINT
+vestingStart:     $VESTING_START
+vestingDuration:  $VESTING_DURATION
+vestedTotalAmount:$VESTED_TOTAL
+tokenURI:         $TOKEN_URI
+bytecodeHash:     $BYTECODE_HASH
+explorer:         https://basescan.org/token/$TOKEN
+EOF
+
+[[ "$NAME" == '"SENTINEL"' ]] || { echo "ERROR: unexpected token name: $NAME" >&2; exit 1; }
+[[ "$SYMBOL" == '"SENTINEL"' ]] || { echo "ERROR: unexpected token symbol: $SYMBOL" >&2; exit 1; }
+[[ "$DECIMALS" == "18" ]] || { echo "ERROR: unexpected decimals: $DECIMALS" >&2; exit 1; }
+
+if [[ "$OWNER" == "0x0000000000000000000000000000000000000000" ]]; then
+  echo "NOTICE: ownership is renounced. Owner-only pool, URI, and mint-rate operations are permanently unavailable."
+else
+  echo "ACTION REQUIRED: confirm owner is the approved multisig/timelock before public launch."
+fi
+
+if [[ "$POOL_UNLOCKED" != "true" ]]; then
+  echo "ACTION REQUIRED: the configured pool is not reported unlocked. Do not claim unrestricted DEX trading."
+fi


### PR DESCRIPTION
## Summary

Registers `0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3` on Base Mainnet as the canonical Aetheron Sentinel L3 ecosystem token and adds release controls around it.

## Changes

- Adds `deployments/base-mainnet.json` as the canonical machine-readable deployment manifest.
- Adds `scripts/verify-canonical-token.sh` to read and validate live token state with Foundry `cast`.
- Adds `docs/SENTINEL_TOKEN_MAINNET.md` covering ownership, multisig, timelock, inflation, pool, liquidity, metadata, and launch evidence.
- Updates README with the canonical address and an explicit warning that `contracts/SentinelToken.sol` is a different token design and is not the verified deployed source.

## Critical finding

The live Base deployment is a verified `DERC20` with 100 billion displayed max supply and symbol `SENTINEL`. The repository's existing `contracts/SentinelToken.sol` instead defines a 1 billion token named `Aetheron Sentinel` with symbol `AETH` and unrestricted owner minting. This PR prevents the two from being represented as the same contract.

## Required before production approval

- Run the verification script against Base Mainnet.
- Populate owner, pool, unlock state, mint rate, vesting, token URI, deployment transaction, and deployer in the manifest from verified evidence.
- Transfer ownership to an approved Safe multisig and document the transaction.
- Add timelock governance or explicitly accept/document the residual risk.
- Publish holder allocation and vesting labels.
- Establish and verify DEX liquidity, LP custody/lock, and buy/sell smoke tests.
- Obtain an independent security review.

No private keys or on-chain administrative transactions are included in this PR.