### PR TITLE
Add external-gate execution pack for issue #210

### DIFF
--- a/.github/workflows/sentinel-final-release.yml
+++ b/.github/workflows/sentinel-final-release.yml
@@ -1,0 +1,30 @@
+name: Sentinel Final Release Verification
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-final-release:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      BASE_RPC_URL: https://base-rpc.publicnode.com
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+      - name: Install locked dependencies
+        run: npm ci --legacy-peer-deps
+      - name: Verify beneficiary signatures
+        run: node scripts/verify-beneficiary-attestations.mjs
+      - name: Reverify authorized buy and sell receipts
+        run: node scripts/verify-sentinel-smoke-test.mjs
+      - name: Verify independent reviewer signoff
+        run: node scripts/verify-sentinel-independent-signoff.mjs
+      - name: Validate final release closure
+        run: node scripts/validate-sentinel-release-closure.mjs --mode=final

--- a/.github/workflows/sentinel-release-closure.yml
+++ b/.github/workflows/sentinel-release-closure.yml
@@ -7,10 +7,13 @@ on:
       - 'scripts/*sentinel*.mjs'
       - 'scripts/verify-sentinel-authority-reachability.sh'
       - 'release-evidence/sentinel-mainnet/release-closure.json'
-      - 'release-evidence/sentinel-mainnet/attestations/manifest.json'
+      - 'release-evidence/sentinel-mainnet/attestations/**'
+      - 'release-evidence/sentinel-mainnet/smoke-test/**'
+      - 'release-evidence/sentinel-mainnet/independent-review/**'
       - 'release-evidence/sentinel-mainnet/authority-reachability*'
       - 'release-evidence/sentinel-mainnet/swaps-decoded/**'
       - '.github/workflows/sentinel-release-closure.yml'
+      - '.github/workflows/sentinel-final-release.yml'
   workflow_dispatch:
 
 permissions:
@@ -30,6 +33,7 @@ jobs:
           node --check scripts/decode-sentinel-v4-swaps.mjs
           node --check scripts/verify-sentinel-smoke-test.mjs
           node --check scripts/verify-beneficiary-attestations.mjs
+          node --check scripts/verify-sentinel-independent-signoff.mjs
           node --check scripts/validate-sentinel-release-closure.mjs
           bash -n scripts/verify-sentinel-authority-reachability.sh
       - name: Validate readiness manifest

--- a/docs/SENTINEL_EXTERNAL_GATE_RUNBOOK.md
+++ b/docs/SENTINEL_EXTERNAL_GATE_RUNBOOK.md
@@ -1,0 +1,89 @@
+# SENTINEL External Gate Execution Runbook
+
+This runbook completes the three remaining external gates tracked by issue #210.
+
+- Beneficiary attestations: #215
+- Authorized minimal buy/sell: #216
+- Independent review and sign-off: #217
+
+The repository, CI, read-only state reproduction, authority analysis, historical routing evidence, and closure validators are complete. These final gates require real wallet controllers, explicit spending authorization, and a genuinely independent reviewer.
+
+## Non-negotiable safety boundary
+
+Never place a private key, mnemonic, wallet export, API secret, or signing session in this repository, GitHub Actions, an issue, a pull request, chat, or a terminal command. Repository automation must remain read-only with respect to production wallets.
+
+No ownership, minting, metadata, migration, fee, beneficiary, liquidity, or treasury action is part of this runbook.
+
+## Gate 1: beneficiary control-and-role attestations
+
+1. Send the appropriate message from `release-evidence/sentinel-mainnet/attestations/SIGNING_REQUESTS.md` to each beneficiary controller.
+2. The controller replaces only the identity and UTC-date placeholders.
+3. The controller signs the exact final message through its normal wallet interface.
+4. Copy the public message and public signature into `release-evidence/sentinel-mainnet/attestations/manifest.json`.
+5. Change that entry from `pending` to `signed`.
+6. Verify all four entries:
+
+```bash
+BASE_RPC_URL=https://base-rpc.publicnode.com \
+  node scripts/verify-beneficiary-attestations.mjs
+```
+
+The 5% Safe must return the EIP-1271 magic value. The three EIP-191 signatures must recover exactly to their beneficiary addresses.
+
+A valid signature proves address control. The independent reviewer must separately verify the stated person, organization, and economic role.
+
+## Gate 2: separately authorized minimal buy and sell
+
+1. Fill every null field in `release-evidence/sentinel-mainnet/smoke-test/authorization.json`.
+2. Post the completed authorization in issue #216 before any transaction is signed.
+3. Use a dedicated non-privileged wallet funded only with the authorized principal and gas reserve.
+4. Confirm Base chain ID `8453`, SENTINEL `0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3`, canonical pool ID `0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d`, route, fee, price impact, and slippage in the wallet interface.
+5. Sign exactly one authorized WETH-to-SENTINEL buy.
+6. Sign exactly one authorized SENTINEL-to-WETH sell.
+7. Verify and preserve the two receipts:
+
+```bash
+export BASE_RPC_URL="https://base-rpc.publicnode.com"
+export SENTINEL_SMOKE_TEST_WALLET="<AUTHORIZED_TEST_WALLET>"
+export SENTINEL_BUY_TX_HASH="<BUY_TX_HASH>"
+export SENTINEL_SELL_TX_HASH="<SELL_TX_HASH>"
+
+node scripts/verify-sentinel-smoke-test.mjs
+```
+
+The verifier writes `smoke-test-receipts.json` and confirms successful canonical-pool events in both directions. It never signs or broadcasts.
+
+## Gate 3: independent review
+
+1. Give the reviewer issue #217 and the complete repository at the exact candidate commit.
+2. The reviewer independently reproduces material claims and reviews the beneficiary attestations and smoke-test receipts.
+3. The reviewer fills `release-evidence/sentinel-mainnet/independent-review/signoff.json`.
+4. Verify the sign-off structure:
+
+```bash
+node scripts/verify-sentinel-independent-signoff.mjs
+```
+
+Only an unconditional `approve` decision can satisfy final-release mode. `approve-with-conditions` and `reject` remain blocking outcomes.
+
+## Final evidence-only pull request
+
+After all three gates pass:
+
+1. Change the three corresponding statuses in `release-evidence/sentinel-mainnet/release-closure.json` from `pending` to `complete`.
+2. Run:
+
+```bash
+BASE_RPC_URL=https://base-rpc.publicnode.com \
+  node scripts/verify-beneficiary-attestations.mjs
+
+BASE_RPC_URL=https://base-rpc.publicnode.com \
+  node scripts/verify-sentinel-smoke-test.mjs
+
+node scripts/verify-sentinel-independent-signoff.mjs
+node scripts/validate-sentinel-release-closure.mjs --mode=final
+```
+
+3. Open an evidence-only pull request referencing #210, #215, #216, and #217.
+4. Require every repository workflow and the manually dispatched `Sentinel Final Release Verification` workflow to pass.
+5. Merge, create the immutable checksum package and release tag, then close all four issues.

--- a/release-evidence/sentinel-mainnet/attestations/SIGNING_REQUESTS.md
+++ b/release-evidence/sentinel-mainnet/attestations/SIGNING_REQUESTS.md
@@ -1,0 +1,87 @@
+# SENTINEL beneficiary signing requests
+
+Each controller must replace `<CONTROLLING PERSON OR ORGANIZATION>` and `<UTC_DATE>` before signing. The exact final message and public signature must then be copied verbatim into `manifest.json`.
+
+Never disclose a private key, mnemonic, wallet export, or signing session.
+
+## 5% Doppler protocol owner — EIP-1271 Safe
+
+```text
+SENTINEL BENEFICIARY CONTROL ATTESTATION
+
+Chain ID: 8453
+Token: 0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3
+Pool ID: 0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d
+Beneficiary address: 0x21E2ce70511e4FE542a97708e89520471DAa7A66
+Configured share: 5%
+Intended economic role: Doppler protocol owner
+Controlling person or organization: <CONTROLLING PERSON OR ORGANIZATION>
+
+I confirm that I control, or am authorized to represent, the beneficiary address above. I approve its configured SENTINEL fee share and acknowledge that the current beneficiary can transfer its share through updateBeneficiary after settling accrued fees.
+
+Issue: MastaTrill/Aetheron-Sentinel-L3#210
+UTC date: <UTC_DATE>
+```
+
+The Safe message must complete its normal threshold-controlled approval process and be exported as EIP-1271-compatible signature bytes.
+
+## 1.9% Bankr ecosystem fund — EIP-191
+
+```text
+SENTINEL BENEFICIARY CONTROL ATTESTATION
+
+Chain ID: 8453
+Token: 0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3
+Pool ID: 0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d
+Beneficiary address: 0x2Cdd33d6FF2a897180c7F4e5a20F018Bf0c16fD1
+Configured share: 1.9%
+Intended economic role: Bankr ecosystem fund
+Controlling person or organization: <CONTROLLING PERSON OR ORGANIZATION>
+
+I confirm that I control, or am authorized to represent, the beneficiary address above. I approve its configured SENTINEL fee share and acknowledge that the current beneficiary can transfer its share through updateBeneficiary after settling accrued fees.
+
+Issue: MastaTrill/Aetheron-Sentinel-L3#210
+UTC date: <UTC_DATE>
+```
+
+## 57% creator fee recipient — EIP-191
+
+```text
+SENTINEL BENEFICIARY CONTROL ATTESTATION
+
+Chain ID: 8453
+Token: 0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3
+Pool ID: 0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d
+Beneficiary address: 0x7e3D11f70084D667295710E6b7FF50C3b0487a45
+Configured share: 57%
+Intended economic role: Creator fee recipient
+Controlling person or organization: <CONTROLLING PERSON OR ORGANIZATION>
+
+I confirm that I control, or am authorized to represent, the beneficiary address above. I approve its configured SENTINEL fee share and acknowledge that the current beneficiary can transfer its share through updateBeneficiary after settling accrued fees.
+
+Issue: MastaTrill/Aetheron-Sentinel-L3#210
+UTC date: <UTC_DATE>
+```
+
+The underlying delegated EOA must sign this message. Do not sign through an unrelated session key or module.
+
+## 36.1% Bankr platform/integrator — EIP-191
+
+```text
+SENTINEL BENEFICIARY CONTROL ATTESTATION
+
+Chain ID: 8453
+Token: 0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3
+Pool ID: 0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d
+Beneficiary address: 0xF60633D02690e2A15A54AB919925F3d038Df163e
+Configured share: 36.1%
+Intended economic role: Bankr platform/integrator
+Controlling person or organization: <CONTROLLING PERSON OR ORGANIZATION>
+
+I confirm that I control, or am authorized to represent, the beneficiary address above. I approve its configured SENTINEL fee share and acknowledge that the current beneficiary can transfer its share through updateBeneficiary after settling accrued fees.
+
+Issue: MastaTrill/Aetheron-Sentinel-L3#210
+UTC date: <UTC_DATE>
+```
+
+The underlying delegated EOA must sign this message. Do not sign through an unrelated session key or module.

--- a/release-evidence/sentinel-mainnet/independent-review/signoff.json
+++ b/release-evidence/sentinel-mainnet/independent-review/signoff.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "status": "pending",
+  "reviewerName": null,
+  "reviewerOrganization": null,
+  "reviewerContact": null,
+  "independenceStatement": null,
+  "reviewedCommit": null,
+  "reviewedAtUtc": null,
+  "decision": null,
+  "methods": [],
+  "evidenceReviewed": [],
+  "findings": [],
+  "unresolvedRisks": [],
+  "signatureReference": null,
+  "notice": "The reviewer must be independent of evidence preparation and wallet control. Only an unconditional approve decision can satisfy final-release mode."
+}

--- a/release-evidence/sentinel-mainnet/release-closure.json
+++ b/release-evidence/sentinel-mainnet/release-closure.json
@@ -56,15 +56,21 @@
     },
     "beneficiaryControlAttestations": {
       "status": "pending",
-      "evidence": ["release-evidence/sentinel-mainnet/attestations/manifest.json"]
+      "evidence": [
+        "release-evidence/sentinel-mainnet/attestations/manifest.json",
+        "release-evidence/sentinel-mainnet/attestations/SIGNING_REQUESTS.md"
+      ]
     },
     "authorizedBuySellSmokeTest": {
       "status": "pending",
-      "evidence": ["release-evidence/sentinel-mainnet/smoke-test/smoke-test-receipts.json"]
+      "evidence": [
+        "release-evidence/sentinel-mainnet/smoke-test/authorization.json",
+        "release-evidence/sentinel-mainnet/smoke-test/smoke-test-receipts.json"
+      ]
     },
     "independentSecuritySignoff": {
       "status": "pending",
-      "evidence": ["release-evidence/sentinel-mainnet/independent-review/signoff.md"]
+      "evidence": ["release-evidence/sentinel-mainnet/independent-review/signoff.json"]
     }
   }
 }

--- a/release-evidence/sentinel-mainnet/smoke-test/authorization.json
+++ b/release-evidence/sentinel-mainnet/smoke-test/authorization.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "status": "pending",
+  "chainId": 8453,
+  "token": "0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3",
+  "weth": "0x4200000000000000000000000000000000000006",
+  "poolManager": "0x498581fF718922c3f8e6A244956aF099B2652b2b",
+  "poolId": "0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d",
+  "authorizedBy": null,
+  "authorizedAtUtc": null,
+  "testWallet": null,
+  "maxWethPrincipalWei": null,
+  "maxTotalGasCostWei": null,
+  "maxSlippageBps": null,
+  "approvedRoute": null,
+  "buyAmountWethWei": null,
+  "sellAmountSentinelWei": null,
+  "authorizationStatement": "I explicitly authorize only the two minimal transactions described in this file. No treasury, beneficiary, owner, migration, fee, minting, metadata, or liquidity action is authorized.",
+  "buyTransactionHash": null,
+  "sellTransactionHash": null,
+  "notice": "Complete and approve this file before signing. Never commit private credentials."
+}

--- a/scripts/validate-sentinel-release-closure.mjs
+++ b/scripts/validate-sentinel-release-closure.mjs
@@ -9,9 +9,21 @@ const manifestPath = process.env.SENTINEL_RELEASE_CLOSURE_MANIFEST ?? 'release-e
 const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
 const failures = [];
 const pending = [];
+const CANONICAL_TOKEN = '0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3';
+const CANONICAL_POOL_ID = '0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d';
+
+async function readJson(file, label) {
+  try {
+    return JSON.parse(await readFile(file, 'utf8'));
+  } catch (error) {
+    failures.push(`${label}: cannot read valid JSON from ${file}: ${error.message}`);
+    return null;
+  }
+}
 
 if (manifest.chainId !== 8453) failures.push('chainId must be 8453');
-if (manifest.token?.toLowerCase() !== '0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3') failures.push('canonical token mismatch');
+if (manifest.token?.toLowerCase() !== CANONICAL_TOKEN) failures.push('canonical token mismatch');
+if (manifest.poolId?.toLowerCase() !== CANONICAL_POOL_ID) failures.push('canonical poolId mismatch');
 
 for (const file of manifest.requiredEvidenceFiles ?? []) {
   try { await access(file); } catch { failures.push(`missing required evidence file: ${file}`); }
@@ -24,6 +36,64 @@ for (const [name, gate] of Object.entries(manifest.gates ?? {})) {
     }
   } else {
     pending.push(`${name}: ${gate.status}`);
+  }
+}
+
+if (mode === 'final') {
+  const attestationGate = manifest.gates?.beneficiaryControlAttestations;
+  if (attestationGate?.status === 'complete') {
+    const attestations = await readJson('release-evidence/sentinel-mainnet/attestations/manifest.json', 'beneficiaryControlAttestations');
+    if (attestations) {
+      if (!Array.isArray(attestations.attestations) || attestations.attestations.length !== 4) {
+        failures.push('beneficiaryControlAttestations: exactly four attestations are required');
+      } else {
+        for (const entry of attestations.attestations) {
+          if (entry.status !== 'signed') failures.push(`${entry.beneficiary ?? 'unknown beneficiary'}: attestation is not signed`);
+          if (typeof entry.message !== 'string' || entry.message.length < 80) failures.push(`${entry.beneficiary ?? 'unknown beneficiary'}: message is missing or too short`);
+          if (typeof entry.signature !== 'string' || !entry.signature.startsWith('0x') || entry.signature.length < 10) failures.push(`${entry.beneficiary ?? 'unknown beneficiary'}: signature is missing or malformed`);
+        }
+      }
+    }
+  }
+
+  const smokeGate = manifest.gates?.authorizedBuySellSmokeTest;
+  if (smokeGate?.status === 'complete') {
+    const authorization = await readJson('release-evidence/sentinel-mainnet/smoke-test/authorization.json', 'authorizedBuySellSmokeTest authorization');
+    const receipts = await readJson('release-evidence/sentinel-mainnet/smoke-test/smoke-test-receipts.json', 'authorizedBuySellSmokeTest receipts');
+
+    if (authorization) {
+      if (authorization.status !== 'authorized') failures.push('authorizedBuySellSmokeTest: authorization status must be authorized');
+      if (authorization.chainId !== 8453) failures.push('authorizedBuySellSmokeTest: authorization chainId mismatch');
+      if (authorization.token?.toLowerCase() !== CANONICAL_TOKEN) failures.push('authorizedBuySellSmokeTest: authorization token mismatch');
+      if (authorization.poolId?.toLowerCase() !== CANONICAL_POOL_ID) failures.push('authorizedBuySellSmokeTest: authorization poolId mismatch');
+    }
+
+    if (receipts) {
+      if (receipts.chainId !== 8453) failures.push('authorizedBuySellSmokeTest: receipt chainId mismatch');
+      if (receipts.poolId?.toLowerCase() !== CANONICAL_POOL_ID) failures.push('authorizedBuySellSmokeTest: receipt poolId mismatch');
+      if (!receipts.buy?.directions?.includes('buy-sentinel-with-weth')) failures.push('authorizedBuySellSmokeTest: verified buy direction is missing');
+      if (!receipts.sell?.directions?.includes('sell-sentinel-for-weth')) failures.push('authorizedBuySellSmokeTest: verified sell direction is missing');
+      if (!/^0x[0-9a-f]{64}$/i.test(receipts.buy?.transactionHash ?? '')) failures.push('authorizedBuySellSmokeTest: buy transaction hash is malformed');
+      if (!/^0x[0-9a-f]{64}$/i.test(receipts.sell?.transactionHash ?? '')) failures.push('authorizedBuySellSmokeTest: sell transaction hash is malformed');
+      if (receipts.buy?.signer?.toLowerCase() !== receipts.sell?.signer?.toLowerCase()) failures.push('authorizedBuySellSmokeTest: buy and sell signers differ');
+      if (authorization?.testWallet && receipts.buy?.signer?.toLowerCase() !== authorization.testWallet.toLowerCase()) failures.push('authorizedBuySellSmokeTest: receipt signer differs from authorized wallet');
+      if (authorization?.buyTransactionHash && receipts.buy?.transactionHash?.toLowerCase() !== authorization.buyTransactionHash.toLowerCase()) failures.push('authorizedBuySellSmokeTest: buy hash differs from authorization');
+      if (authorization?.sellTransactionHash && receipts.sell?.transactionHash?.toLowerCase() !== authorization.sellTransactionHash.toLowerCase()) failures.push('authorizedBuySellSmokeTest: sell hash differs from authorization');
+    }
+  }
+
+  const signoffGate = manifest.gates?.independentSecuritySignoff;
+  if (signoffGate?.status === 'complete') {
+    const signoff = await readJson('release-evidence/sentinel-mainnet/independent-review/signoff.json', 'independentSecuritySignoff');
+    if (signoff) {
+      if (signoff.status !== 'signed') failures.push('independentSecuritySignoff: status must be signed');
+      if (signoff.decision !== 'approve') failures.push('independentSecuritySignoff: decision must be approve');
+      if (!/^[0-9a-f]{40}$/i.test(signoff.reviewedCommit ?? '')) failures.push('independentSecuritySignoff: reviewedCommit must be an exact commit SHA');
+      if (typeof signoff.reviewerName !== 'string' || signoff.reviewerName.trim().length < 2) failures.push('independentSecuritySignoff: reviewerName is missing');
+      if (typeof signoff.independenceStatement !== 'string' || signoff.independenceStatement.trim().length < 40) failures.push('independentSecuritySignoff: independenceStatement is missing or too short');
+      if (!Array.isArray(signoff.evidenceReviewed) || signoff.evidenceReviewed.length < 5) failures.push('independentSecuritySignoff: evidenceReviewed is incomplete');
+      if (typeof signoff.signatureReference !== 'string' || signoff.signatureReference.trim().length < 8) failures.push('independentSecuritySignoff: signatureReference is missing');
+    }
   }
 }
 

--- a/scripts/verify-sentinel-independent-signoff.mjs
+++ b/scripts/verify-sentinel-independent-signoff.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+
+const signoffPath = process.env.SENTINEL_INDEPENDENT_SIGNOFF
+  ?? 'release-evidence/sentinel-mainnet/independent-review/signoff.json';
+
+const signoff = JSON.parse(await readFile(signoffPath, 'utf8'));
+const failures = [];
+
+function requireText(name, value, minimumLength = 1) {
+  if (typeof value !== 'string' || value.trim().length < minimumLength) {
+    failures.push(`${name} is missing or too short`);
+    return;
+  }
+  if (/[<>]/.test(value) || /\b(TBD|TODO|PLACEHOLDER)\b/i.test(value)) {
+    failures.push(`${name} contains a placeholder`);
+  }
+}
+
+if (signoff.schemaVersion !== 1) failures.push('schemaVersion must be 1');
+if (signoff.status !== 'signed') failures.push(`status must be signed, found ${signoff.status ?? 'missing'}`);
+requireText('reviewerName', signoff.reviewerName, 2);
+requireText('reviewerContact', signoff.reviewerContact, 3);
+requireText('independenceStatement', signoff.independenceStatement, 40);
+requireText('signatureReference', signoff.signatureReference, 8);
+
+if (typeof signoff.reviewedCommit !== 'string' || !/^[0-9a-f]{40}$/i.test(signoff.reviewedCommit)) {
+  failures.push('reviewedCommit must be an exact 40-character commit SHA');
+}
+
+if (typeof signoff.reviewedAtUtc !== 'string' || Number.isNaN(Date.parse(signoff.reviewedAtUtc))) {
+  failures.push('reviewedAtUtc must be a valid timestamp');
+}
+
+if (signoff.decision !== 'approve') {
+  failures.push(`decision must be approve for final release, found ${signoff.decision ?? 'missing'}`);
+}
+
+if (!Array.isArray(signoff.methods) || signoff.methods.length < 2) {
+  failures.push('methods must contain at least two independent review methods');
+}
+if (!Array.isArray(signoff.evidenceReviewed) || signoff.evidenceReviewed.length < 5) {
+  failures.push('evidenceReviewed must list at least five reviewed evidence items');
+}
+if (!Array.isArray(signoff.findings) || signoff.findings.length < 1) {
+  failures.push('findings must contain at least one review finding');
+}
+if (!Array.isArray(signoff.unresolvedRisks)) {
+  failures.push('unresolvedRisks must be an array, even when empty');
+}
+
+if (failures.length) {
+  console.error('Independent sign-off is incomplete or invalid:\n- ' + failures.join('\n- '));
+  process.exit(1);
+}
+
+console.log(`Independent sign-off verified for commit ${signoff.reviewedCommit} by ${signoff.reviewerName}.`);

--- a/scripts/verify-sentinel-smoke-test.mjs
+++ b/scripts/verify-sentinel-smoke-test.mjs
@@ -1,17 +1,57 @@
 #!/usr/bin/env node
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { Interface, JsonRpcProvider, getAddress } from 'ethers';
 
 const RPC_URL = process.env.BASE_RPC_URL ?? 'https://base-rpc.publicnode.com';
-const BUY_TX_HASH = process.env.SENTINEL_BUY_TX_HASH;
-const SELL_TX_HASH = process.env.SENTINEL_SELL_TX_HASH;
-const EXPECTED_WALLET = process.env.SENTINEL_SMOKE_TEST_WALLET ? getAddress(process.env.SENTINEL_SMOKE_TEST_WALLET) : null;
 const POOL_MANAGER = getAddress(process.env.SENTINEL_POOL_MANAGER ?? '0x498581fF718922c3f8e6A244956aF099B2652b2b');
 const POOL_ID = (process.env.SENTINEL_POOL_ID ?? '0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d').toLowerCase();
 const OUTPUT_DIR = process.env.SENTINEL_SMOKE_OUTPUT_DIR ?? 'release-evidence/sentinel-mainnet/smoke-test';
+const RECEIPTS_PATH = path.join(OUTPUT_DIR, 'smoke-test-receipts.json');
+const AUTHORIZATION_PATH = process.env.SENTINEL_SMOKE_AUTHORIZATION
+  ?? path.join(OUTPUT_DIR, 'authorization.json');
 
-if (!BUY_TX_HASH || !SELL_TX_HASH) throw new Error('Set SENTINEL_BUY_TX_HASH and SENTINEL_SELL_TX_HASH. This verifier never signs or broadcasts transactions.');
+const authorization = JSON.parse(await readFile(AUTHORIZATION_PATH, 'utf8'));
+const authorizationFailures = [];
+
+if (authorization.schemaVersion !== 1) authorizationFailures.push('authorization schemaVersion must be 1');
+if (authorization.status !== 'authorized') authorizationFailures.push(`authorization status must be authorized, found ${authorization.status ?? 'missing'}`);
+if (authorization.chainId !== 8453) authorizationFailures.push('authorization chainId must be 8453');
+if (authorization.token?.toLowerCase() !== '0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3') authorizationFailures.push('authorization token mismatch');
+if (authorization.poolId?.toLowerCase() !== POOL_ID) authorizationFailures.push('authorization poolId mismatch');
+
+for (const field of ['authorizedBy', 'authorizedAtUtc', 'testWallet', 'maxWethPrincipalWei', 'maxTotalGasCostWei', 'maxSlippageBps', 'approvedRoute', 'buyAmountWethWei', 'sellAmountSentinelWei']) {
+  if (authorization[field] === null || authorization[field] === undefined || authorization[field] === '') {
+    authorizationFailures.push(`authorization field ${field} is missing`);
+  }
+}
+
+if (authorizationFailures.length) {
+  console.error('Smoke-test authorization is incomplete or invalid:\n- ' + authorizationFailures.join('\n- '));
+  process.exit(1);
+}
+
+let BUY_TX_HASH = process.env.SENTINEL_BUY_TX_HASH ?? authorization.buyTransactionHash;
+let SELL_TX_HASH = process.env.SENTINEL_SELL_TX_HASH ?? authorization.sellTransactionHash;
+let expectedWalletInput = process.env.SENTINEL_SMOKE_TEST_WALLET ?? authorization.testWallet;
+
+if (!BUY_TX_HASH || !SELL_TX_HASH) {
+  try {
+    const existing = JSON.parse(await readFile(RECEIPTS_PATH, 'utf8'));
+    BUY_TX_HASH ??= existing.buy?.transactionHash;
+    SELL_TX_HASH ??= existing.sell?.transactionHash;
+    expectedWalletInput ??= existing.expectedWallet ?? existing.buy?.signer;
+  } catch {
+    // The receipt file is created only after both transaction hashes are supplied.
+  }
+}
+
+if (!BUY_TX_HASH || !SELL_TX_HASH) {
+  throw new Error('Set SENTINEL_BUY_TX_HASH and SENTINEL_SELL_TX_HASH or record them in authorization.json. This verifier never signs or broadcasts transactions.');
+}
+
+const EXPECTED_WALLET = getAddress(expectedWalletInput);
+if (getAddress(authorization.testWallet) !== EXPECTED_WALLET) throw new Error('Expected wallet does not match authorization.testWallet');
 
 const provider = new JsonRpcProvider(RPC_URL, 8453, { staticNetwork: true });
 const iface = new Interface([
@@ -22,7 +62,7 @@ async function verify(hash, expectedDirection) {
   const [tx, receipt] = await Promise.all([provider.getTransaction(hash), provider.getTransactionReceipt(hash)]);
   if (!tx || !receipt) throw new Error(`Transaction not found: ${hash}`);
   if (receipt.status !== 1) throw new Error(`Transaction reverted: ${hash}`);
-  if (EXPECTED_WALLET && getAddress(tx.from) !== EXPECTED_WALLET) throw new Error(`Unexpected signer for ${hash}: ${tx.from}`);
+  if (getAddress(tx.from) !== EXPECTED_WALLET) throw new Error(`Unexpected signer for ${hash}: ${tx.from}`);
 
   const matching = receipt.logs
     .filter((log) => log.address.toLowerCase() === POOL_MANAGER.toLowerCase())
@@ -41,6 +81,25 @@ async function verify(hash, expectedDirection) {
   });
   if (!directions.includes(expectedDirection)) throw new Error(`${hash} does not contain expected direction ${expectedDirection}; found ${directions.join(', ')}`);
 
+  let wethIn = 0n;
+  let wethOut = 0n;
+  let sentinelIn = 0n;
+  let sentinelOut = 0n;
+  for (const parsed of matching) {
+    const amount0 = parsed.args.amount0;
+    const amount1 = parsed.args.amount1;
+    if (amount0 > 0n && amount1 < 0n) {
+      wethIn += amount0;
+      sentinelOut += -amount1;
+    } else if (amount0 < 0n && amount1 > 0n) {
+      wethOut += -amount0;
+      sentinelIn += amount1;
+    }
+  }
+
+  const gasPrice = receipt.gasPrice ?? tx.gasPrice ?? 0n;
+  const gasCost = receipt.gasUsed * gasPrice;
+
   return {
     transactionHash: hash,
     blockNumber: receipt.blockNumber,
@@ -48,12 +107,30 @@ async function verify(hash, expectedDirection) {
     entrypoint: tx.to ? getAddress(tx.to) : null,
     inputSelector: tx.data.slice(0, 10),
     gasUsed: receipt.gasUsed.toString(),
+    gasPriceWei: gasPrice.toString(),
+    gasCostWei: gasCost.toString(),
     directions,
+    canonicalPoolAmounts: {
+      wethInWei: wethIn.toString(),
+      wethOutWei: wethOut.toString(),
+      sentinelInWei: sentinelIn.toString(),
+      sentinelOutWei: sentinelOut.toString(),
+    },
   };
 }
 
 const buy = await verify(BUY_TX_HASH, 'buy-sentinel-with-weth');
 const sell = await verify(SELL_TX_HASH, 'sell-sentinel-for-weth');
+
+const actualBuyWeth = BigInt(buy.canonicalPoolAmounts.wethInWei);
+const actualSellSentinel = BigInt(sell.canonicalPoolAmounts.sentinelInWei);
+const totalGasCost = BigInt(buy.gasCostWei) + BigInt(sell.gasCostWei);
+
+if (actualBuyWeth > BigInt(authorization.buyAmountWethWei)) throw new Error('Actual buy WETH exceeds authorized buyAmountWethWei');
+if (actualBuyWeth > BigInt(authorization.maxWethPrincipalWei)) throw new Error('Actual buy WETH exceeds maxWethPrincipalWei');
+if (actualSellSentinel > BigInt(authorization.sellAmountSentinelWei)) throw new Error('Actual sell SENTINEL exceeds sellAmountSentinelWei');
+if (totalGasCost > BigInt(authorization.maxTotalGasCostWei)) throw new Error('Actual total gas cost exceeds maxTotalGasCostWei');
+
 const result = {
   schemaVersion: 1,
   verifiedAtUtc: new Date().toISOString(),
@@ -61,13 +138,24 @@ const result = {
   poolManager: POOL_MANAGER,
   poolId: POOL_ID,
   expectedWallet: EXPECTED_WALLET,
+  authorization: {
+    authorizedBy: authorization.authorizedBy,
+    authorizedAtUtc: authorization.authorizedAtUtc,
+    maxWethPrincipalWei: String(authorization.maxWethPrincipalWei),
+    maxTotalGasCostWei: String(authorization.maxTotalGasCostWei),
+    maxSlippageBps: String(authorization.maxSlippageBps),
+    approvedRoute: authorization.approvedRoute,
+    buyAmountWethWei: String(authorization.buyAmountWethWei),
+    sellAmountSentinelWei: String(authorization.sellAmountSentinelWei),
+  },
+  observedTotalGasCostWei: totalGasCost.toString(),
   buy,
   sell,
   notice: 'Receipt verification only. The verifier never signs or broadcasts transactions.',
 };
 
 await mkdir(OUTPUT_DIR, { recursive: true });
-await writeFile(path.join(OUTPUT_DIR, 'smoke-test-receipts.json'), `${JSON.stringify(result, null, 2)}\n`);
-await writeFile(path.join(OUTPUT_DIR, 'README.md'), `# SENTINEL minimal buy/sell smoke-test evidence\n\n- Verified: ${result.verifiedAtUtc}\n- Buy transaction: \`${BUY_TX_HASH}\`\n- Sell transaction: \`${SELL_TX_HASH}\`\n- Pool ID: \`${POOL_ID}\`\n- Signer: \`${buy.signer}\`\n\nBoth receipts succeeded and emitted canonical-pool Swap events in the expected directions.\n`);
+await writeFile(RECEIPTS_PATH, `${JSON.stringify(result, null, 2)}\n`);
+await writeFile(path.join(OUTPUT_DIR, 'README.md'), `# SENTINEL minimal buy/sell smoke-test evidence\n\n- Verified: ${result.verifiedAtUtc}\n- Buy transaction: \`${BUY_TX_HASH}\`\n- Sell transaction: \`${SELL_TX_HASH}\`\n- Pool ID: \`${POOL_ID}\`\n- Signer: \`${buy.signer}\`\n- Total gas cost (wei): \`${totalGasCost}\`\n\nBoth receipts succeeded, stayed within the recorded principal/gas authorization, and emitted canonical-pool Swap events in the expected directions. Slippage approval must be checked against the signed wallet quotes and independently reviewed.\n`);
 console.log(JSON.stringify(result, null, 2));
 await provider.destroy();


### PR DESCRIPTION
## Summary

Adds the complete execution pack for the three external gates that remain after PR #214:

- exact beneficiary signing requests and issue #215;
- a machine-readable, fail-closed smoke-test authorization record and issue #216;
- a structured independent-review signoff record and issue #217;
- an operator runbook linking all three tasks;
- stronger final-mode structural validation;
- a manual end-to-end final-release verification workflow.

## Safety boundary

This PR does not sign a wallet message, disclose credentials, authorize a trade, broadcast a transaction, claim beneficiary identity, or claim independent approval. All three external gates remain pending.

The smoke-test verifier now refuses to run unless `authorization.json` is explicitly marked `authorized`, validates the authorized wallet and canonical identifiers, rechecks both receipts from Base, records canonical-pool amounts and gas costs, and fails if principal, sell amount, or total gas exceeds the authorization.

Final-release mode rejects placeholder signatures, malformed receipts, conditional reviewer decisions, and incomplete signoff records.

## Testing

GitHub Actions are the source of truth. The focused closure workflow will run these checks:

```bash
node --check scripts/verify-sentinel-smoke-test.mjs
node --check scripts/verify-sentinel-independent-signoff.mjs
node --check scripts/validate-sentinel-release-closure.mjs
node scripts/validate-sentinel-release-closure.mjs --mode=readiness
```

The manual `Sentinel Final Release Verification` workflow is intentionally not expected to pass until issues #215, #216, and #217 contain real external evidence and the three release-manifest statuses are changed to `complete`.

Refs #210
Refs #215
Refs #216
Refs #217