### PR TITLE
Harden final SENTINEL release evidence validation

### DIFF
--- a/docs/vercel-status.html
+++ b/docs/vercel-status.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Aetheron Sentinel L3</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 760px; margin: 4rem auto; padding: 0 1.25rem; line-height: 1.6; }
+    code { background: #f3f4f6; padding: 0.15rem 0.35rem; border-radius: 0.25rem; }
+  </style>
+</head>
+<body>
+  <h1>Aetheron Sentinel L3</h1>
+  <p>This repository contains the Sentinel L3 smart-contract and release-evidence toolchain.</p>
+  <p>Application builds and security validation run in GitHub Actions. This static page exists only to keep the linked Vercel project healthy without installing the repository's local Python research and audit environment.</p>
+  <p>Canonical network: <code>Base</code></p>
+</body>
+</html>

--- a/scripts/validate-sentinel-release-closure.mjs
+++ b/scripts/validate-sentinel-release-closure.mjs
@@ -11,6 +11,15 @@ const failures = [];
 const pending = [];
 const CANONICAL_TOKEN = '0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3';
 const CANONICAL_POOL_ID = '0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d';
+const ETH_SIGNATURE_PATTERN = /^0x[0-9a-f]{130}$/i;
+const PLACEHOLDER_PATTERN = /^(?:0x)?(?:0+|f+|deadbeef|cafebabe|1234(?:5678)?|todo|tbd|placeholder)$/i;
+
+function isValidSignature(value) {
+  if (typeof value !== 'string' || !ETH_SIGNATURE_PATTERN.test(value)) return false;
+  const body = value.slice(2).toLowerCase();
+  if (/^(.)\1+$/.test(body)) return false;
+  return !PLACEHOLDER_PATTERN.test(value);
+}
 
 async function readJson(file, label) {
   try {
@@ -50,7 +59,7 @@ if (mode === 'final') {
         for (const entry of attestations.attestations) {
           if (entry.status !== 'signed') failures.push(`${entry.beneficiary ?? 'unknown beneficiary'}: attestation is not signed`);
           if (typeof entry.message !== 'string' || entry.message.length < 80) failures.push(`${entry.beneficiary ?? 'unknown beneficiary'}: message is missing or too short`);
-          if (typeof entry.signature !== 'string' || !entry.signature.startsWith('0x') || entry.signature.length < 10) failures.push(`${entry.beneficiary ?? 'unknown beneficiary'}: signature is missing or malformed`);
+          if (!isValidSignature(entry.signature)) failures.push(`${entry.beneficiary ?? 'unknown beneficiary'}: signature must be a non-placeholder 65-byte Ethereum signature`);
         }
       }
     }
@@ -66,6 +75,8 @@ if (mode === 'final') {
       if (authorization.chainId !== 8453) failures.push('authorizedBuySellSmokeTest: authorization chainId mismatch');
       if (authorization.token?.toLowerCase() !== CANONICAL_TOKEN) failures.push('authorizedBuySellSmokeTest: authorization token mismatch');
       if (authorization.poolId?.toLowerCase() !== CANONICAL_POOL_ID) failures.push('authorizedBuySellSmokeTest: authorization poolId mismatch');
+      if (!/^0x[0-9a-f]{64}$/i.test(authorization.buyTransactionHash ?? '')) failures.push('authorizedBuySellSmokeTest: authorization buy transaction hash is malformed');
+      if (!/^0x[0-9a-f]{64}$/i.test(authorization.sellTransactionHash ?? '')) failures.push('authorizedBuySellSmokeTest: authorization sell transaction hash is malformed');
     }
 
     if (receipts) {
@@ -77,8 +88,8 @@ if (mode === 'final') {
       if (!/^0x[0-9a-f]{64}$/i.test(receipts.sell?.transactionHash ?? '')) failures.push('authorizedBuySellSmokeTest: sell transaction hash is malformed');
       if (receipts.buy?.signer?.toLowerCase() !== receipts.sell?.signer?.toLowerCase()) failures.push('authorizedBuySellSmokeTest: buy and sell signers differ');
       if (authorization?.testWallet && receipts.buy?.signer?.toLowerCase() !== authorization.testWallet.toLowerCase()) failures.push('authorizedBuySellSmokeTest: receipt signer differs from authorized wallet');
-      if (authorization?.buyTransactionHash && receipts.buy?.transactionHash?.toLowerCase() !== authorization.buyTransactionHash.toLowerCase()) failures.push('authorizedBuySellSmokeTest: buy hash differs from authorization');
-      if (authorization?.sellTransactionHash && receipts.sell?.transactionHash?.toLowerCase() !== authorization.sellTransactionHash.toLowerCase()) failures.push('authorizedBuySellSmokeTest: sell hash differs from authorization');
+      if (authorization?.buyTransactionHash?.toLowerCase() !== receipts.buy?.transactionHash?.toLowerCase()) failures.push('authorizedBuySellSmokeTest: buy hash differs from authorization');
+      if (authorization?.sellTransactionHash?.toLowerCase() !== receipts.sell?.transactionHash?.toLowerCase()) failures.push('authorizedBuySellSmokeTest: sell hash differs from authorization');
     }
   }
 
@@ -92,7 +103,7 @@ if (mode === 'final') {
       if (typeof signoff.reviewerName !== 'string' || signoff.reviewerName.trim().length < 2) failures.push('independentSecuritySignoff: reviewerName is missing');
       if (typeof signoff.independenceStatement !== 'string' || signoff.independenceStatement.trim().length < 40) failures.push('independentSecuritySignoff: independenceStatement is missing or too short');
       if (!Array.isArray(signoff.evidenceReviewed) || signoff.evidenceReviewed.length < 5) failures.push('independentSecuritySignoff: evidenceReviewed is incomplete');
-      if (typeof signoff.signatureReference !== 'string' || signoff.signatureReference.trim().length < 8) failures.push('independentSecuritySignoff: signatureReference is missing');
+      if (typeof signoff.signatureReference !== 'string' || signoff.signatureReference.trim().length < 8 || PLACEHOLDER_PATTERN.test(signoff.signatureReference.trim())) failures.push('independentSecuritySignoff: signatureReference is missing or placeholder-like');
     }
   }
 }

--- a/scripts/validate-sentinel-release-closure.mjs
+++ b/scripts/validate-sentinel-release-closure.mjs
@@ -11,14 +11,34 @@ const failures = [];
 const pending = [];
 const CANONICAL_TOKEN = '0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3';
 const CANONICAL_POOL_ID = '0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d';
-const ETH_SIGNATURE_PATTERN = /^0x[0-9a-f]{130}$/i;
-const PLACEHOLDER_PATTERN = /^(?:0x)?(?:0+|f+|deadbeef|cafebabe|1234(?:5678)?|todo|tbd|placeholder)$/i;
+const EIP191_SIGNATURE_PATTERN = /^0x[0-9a-f]{130}$/i;
+const HEX_BYTES_PATTERN = /^0x(?:[0-9a-f]{2})+$/i;
+const EXACT_PLACEHOLDER_PATTERN = /^(?:0x)?(?:0+|f+|deadbeef|cafebabe|1234(?:5678)?|todo|tbd|pending|placeholder)$/i;
+const PLACEHOLDER_TOKEN_PATTERN = /\b(?:TODO|TBD|PENDING|PLACEHOLDER)\b/i;
 
-function isValidSignature(value) {
-  if (typeof value !== 'string' || !ETH_SIGNATURE_PATTERN.test(value)) return false;
+function isRepeatedHex(value) {
+  if (typeof value !== 'string' || !value.startsWith('0x')) return false;
   const body = value.slice(2).toLowerCase();
-  if (/^(.)\1+$/.test(body)) return false;
-  return !PLACEHOLDER_PATTERN.test(value);
+  return body.length > 0 && /^(.)\1+$/.test(body);
+}
+
+function isPlaceholderLike(value) {
+  if (typeof value !== 'string') return true;
+  const normalized = value.trim();
+  return normalized.length === 0
+    || /[<>]/.test(normalized)
+    || EXACT_PLACEHOLDER_PATTERN.test(normalized)
+    || PLACEHOLDER_TOKEN_PATTERN.test(normalized)
+    || isRepeatedHex(normalized);
+}
+
+function isValidAttestationSignature(entry) {
+  const signature = entry?.signature;
+  const verificationMode = String(entry?.verificationMode ?? '').toLowerCase();
+  if (typeof signature !== 'string' || isPlaceholderLike(signature)) return false;
+  if (verificationMode === 'eip191') return EIP191_SIGNATURE_PATTERN.test(signature);
+  if (verificationMode === 'eip1271') return HEX_BYTES_PATTERN.test(signature) && signature.length >= 132;
+  return false;
 }
 
 async function readJson(file, label) {
@@ -57,9 +77,17 @@ if (mode === 'final') {
         failures.push('beneficiaryControlAttestations: exactly four attestations are required');
       } else {
         for (const entry of attestations.attestations) {
-          if (entry.status !== 'signed') failures.push(`${entry.beneficiary ?? 'unknown beneficiary'}: attestation is not signed`);
-          if (typeof entry.message !== 'string' || entry.message.length < 80) failures.push(`${entry.beneficiary ?? 'unknown beneficiary'}: message is missing or too short`);
-          if (!isValidSignature(entry.signature)) failures.push(`${entry.beneficiary ?? 'unknown beneficiary'}: signature must be a non-placeholder 65-byte Ethereum signature`);
+          const beneficiary = entry.beneficiary ?? 'unknown beneficiary';
+          const verificationMode = String(entry.verificationMode ?? '').toLowerCase();
+          if (entry.status !== 'signed') failures.push(`${beneficiary}: attestation is not signed`);
+          if (typeof entry.message !== 'string' || entry.message.length < 80) failures.push(`${beneficiary}: message is missing or too short`);
+          if (!['eip191', 'eip1271'].includes(verificationMode)) failures.push(`${beneficiary}: verificationMode must be eip191 or eip1271`);
+          if (!isValidAttestationSignature(entry)) {
+            const expected = verificationMode === 'eip1271'
+              ? 'non-placeholder variable-length EIP-1271 hex bytes'
+              : 'non-placeholder 65-byte EIP-191 signature';
+            failures.push(`${beneficiary}: signature must be ${expected}`);
+          }
         }
       }
     }
@@ -103,7 +131,7 @@ if (mode === 'final') {
       if (typeof signoff.reviewerName !== 'string' || signoff.reviewerName.trim().length < 2) failures.push('independentSecuritySignoff: reviewerName is missing');
       if (typeof signoff.independenceStatement !== 'string' || signoff.independenceStatement.trim().length < 40) failures.push('independentSecuritySignoff: independenceStatement is missing or too short');
       if (!Array.isArray(signoff.evidenceReviewed) || signoff.evidenceReviewed.length < 5) failures.push('independentSecuritySignoff: evidenceReviewed is incomplete');
-      if (typeof signoff.signatureReference !== 'string' || signoff.signatureReference.trim().length < 8 || PLACEHOLDER_PATTERN.test(signoff.signatureReference.trim())) failures.push('independentSecuritySignoff: signatureReference is missing or placeholder-like');
+      if (typeof signoff.signatureReference !== 'string' || signoff.signatureReference.trim().length < 8 || isPlaceholderLike(signoff.signatureReference)) failures.push('independentSecuritySignoff: signatureReference is missing or placeholder-like');
     }
   }
 }

--- a/scripts/verify-sentinel-smoke-test.mjs
+++ b/scripts/verify-sentinel-smoke-test.mjs
@@ -10,6 +10,7 @@ const OUTPUT_DIR = process.env.SENTINEL_SMOKE_OUTPUT_DIR ?? 'release-evidence/se
 const RECEIPTS_PATH = path.join(OUTPUT_DIR, 'smoke-test-receipts.json');
 const AUTHORIZATION_PATH = process.env.SENTINEL_SMOKE_AUTHORIZATION
   ?? path.join(OUTPUT_DIR, 'authorization.json');
+const TX_HASH_PATTERN = /^0x[0-9a-f]{64}$/i;
 
 const authorization = JSON.parse(await readFile(AUTHORIZATION_PATH, 'utf8'));
 const authorizationFailures = [];
@@ -20,38 +21,32 @@ if (authorization.chainId !== 8453) authorizationFailures.push('authorization ch
 if (authorization.token?.toLowerCase() !== '0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3') authorizationFailures.push('authorization token mismatch');
 if (authorization.poolId?.toLowerCase() !== POOL_ID) authorizationFailures.push('authorization poolId mismatch');
 
-for (const field of ['authorizedBy', 'authorizedAtUtc', 'testWallet', 'maxWethPrincipalWei', 'maxTotalGasCostWei', 'maxSlippageBps', 'approvedRoute', 'buyAmountWethWei', 'sellAmountSentinelWei']) {
+for (const field of ['authorizedBy', 'authorizedAtUtc', 'testWallet', 'maxWethPrincipalWei', 'maxTotalGasCostWei', 'maxSlippageBps', 'approvedRoute', 'buyAmountWethWei', 'sellAmountSentinelWei', 'buyTransactionHash', 'sellTransactionHash']) {
   if (authorization[field] === null || authorization[field] === undefined || authorization[field] === '') {
     authorizationFailures.push(`authorization field ${field} is missing`);
   }
 }
+if (!TX_HASH_PATTERN.test(authorization.buyTransactionHash ?? '')) authorizationFailures.push('authorization buyTransactionHash is malformed');
+if (!TX_HASH_PATTERN.test(authorization.sellTransactionHash ?? '')) authorizationFailures.push('authorization sellTransactionHash is malformed');
 
 if (authorizationFailures.length) {
   console.error('Smoke-test authorization is incomplete or invalid:\n- ' + authorizationFailures.join('\n- '));
   process.exit(1);
 }
 
-let BUY_TX_HASH = process.env.SENTINEL_BUY_TX_HASH ?? authorization.buyTransactionHash;
-let SELL_TX_HASH = process.env.SENTINEL_SELL_TX_HASH ?? authorization.sellTransactionHash;
-let expectedWalletInput = process.env.SENTINEL_SMOKE_TEST_WALLET ?? authorization.testWallet;
+const BUY_TX_HASH = authorization.buyTransactionHash;
+const SELL_TX_HASH = authorization.sellTransactionHash;
+const EXPECTED_WALLET = getAddress(authorization.testWallet);
 
-if (!BUY_TX_HASH || !SELL_TX_HASH) {
-  try {
-    const existing = JSON.parse(await readFile(RECEIPTS_PATH, 'utf8'));
-    BUY_TX_HASH ??= existing.buy?.transactionHash;
-    SELL_TX_HASH ??= existing.sell?.transactionHash;
-    expectedWalletInput ??= existing.expectedWallet ?? existing.buy?.signer;
-  } catch {
-    // The receipt file is created only after both transaction hashes are supplied.
-  }
+if (process.env.SENTINEL_BUY_TX_HASH && process.env.SENTINEL_BUY_TX_HASH.toLowerCase() !== BUY_TX_HASH.toLowerCase()) {
+  throw new Error('SENTINEL_BUY_TX_HASH differs from authorization.buyTransactionHash');
 }
-
-if (!BUY_TX_HASH || !SELL_TX_HASH) {
-  throw new Error('Set SENTINEL_BUY_TX_HASH and SENTINEL_SELL_TX_HASH or record them in authorization.json. This verifier never signs or broadcasts transactions.');
+if (process.env.SENTINEL_SELL_TX_HASH && process.env.SENTINEL_SELL_TX_HASH.toLowerCase() !== SELL_TX_HASH.toLowerCase()) {
+  throw new Error('SENTINEL_SELL_TX_HASH differs from authorization.sellTransactionHash');
 }
-
-const EXPECTED_WALLET = getAddress(expectedWalletInput);
-if (getAddress(authorization.testWallet) !== EXPECTED_WALLET) throw new Error('Expected wallet does not match authorization.testWallet');
+if (process.env.SENTINEL_SMOKE_TEST_WALLET && getAddress(process.env.SENTINEL_SMOKE_TEST_WALLET) !== EXPECTED_WALLET) {
+  throw new Error('SENTINEL_SMOKE_TEST_WALLET differs from authorization.testWallet');
+}
 
 const provider = new JsonRpcProvider(RPC_URL, 8453, { staticNetwork: true });
 const iface = new Interface([
@@ -97,7 +92,8 @@ async function verify(hash, expectedDirection) {
     }
   }
 
-  const gasPrice = receipt.gasPrice ?? tx.gasPrice ?? 0n;
+  const gasPrice = receipt.effectiveGasPrice ?? receipt.gasPrice ?? tx.gasPrice;
+  if (gasPrice === null || gasPrice === undefined) throw new Error(`Cannot determine authoritative gas price for ${hash}`);
   const gasCost = receipt.gasUsed * gasPrice;
 
   return {
@@ -119,43 +115,48 @@ async function verify(hash, expectedDirection) {
   };
 }
 
-const buy = await verify(BUY_TX_HASH, 'buy-sentinel-with-weth');
-const sell = await verify(SELL_TX_HASH, 'sell-sentinel-for-weth');
+try {
+  const buy = await verify(BUY_TX_HASH, 'buy-sentinel-with-weth');
+  const sell = await verify(SELL_TX_HASH, 'sell-sentinel-for-weth');
 
-const actualBuyWeth = BigInt(buy.canonicalPoolAmounts.wethInWei);
-const actualSellSentinel = BigInt(sell.canonicalPoolAmounts.sentinelInWei);
-const totalGasCost = BigInt(buy.gasCostWei) + BigInt(sell.gasCostWei);
+  const actualBuyWeth = BigInt(buy.canonicalPoolAmounts.wethInWei);
+  const actualSellSentinel = BigInt(sell.canonicalPoolAmounts.sentinelInWei);
+  const totalGasCost = BigInt(buy.gasCostWei) + BigInt(sell.gasCostWei);
 
-if (actualBuyWeth > BigInt(authorization.buyAmountWethWei)) throw new Error('Actual buy WETH exceeds authorized buyAmountWethWei');
-if (actualBuyWeth > BigInt(authorization.maxWethPrincipalWei)) throw new Error('Actual buy WETH exceeds maxWethPrincipalWei');
-if (actualSellSentinel > BigInt(authorization.sellAmountSentinelWei)) throw new Error('Actual sell SENTINEL exceeds sellAmountSentinelWei');
-if (totalGasCost > BigInt(authorization.maxTotalGasCostWei)) throw new Error('Actual total gas cost exceeds maxTotalGasCostWei');
+  if (actualBuyWeth > BigInt(authorization.buyAmountWethWei)) throw new Error('Actual buy WETH exceeds authorized buyAmountWethWei');
+  if (actualBuyWeth > BigInt(authorization.maxWethPrincipalWei)) throw new Error('Actual buy WETH exceeds maxWethPrincipalWei');
+  if (actualSellSentinel > BigInt(authorization.sellAmountSentinelWei)) throw new Error('Actual sell SENTINEL exceeds sellAmountSentinelWei');
+  if (totalGasCost > BigInt(authorization.maxTotalGasCostWei)) throw new Error('Actual total gas cost exceeds maxTotalGasCostWei');
 
-const result = {
-  schemaVersion: 1,
-  verifiedAtUtc: new Date().toISOString(),
-  chainId: 8453,
-  poolManager: POOL_MANAGER,
-  poolId: POOL_ID,
-  expectedWallet: EXPECTED_WALLET,
-  authorization: {
-    authorizedBy: authorization.authorizedBy,
-    authorizedAtUtc: authorization.authorizedAtUtc,
-    maxWethPrincipalWei: String(authorization.maxWethPrincipalWei),
-    maxTotalGasCostWei: String(authorization.maxTotalGasCostWei),
-    maxSlippageBps: String(authorization.maxSlippageBps),
-    approvedRoute: authorization.approvedRoute,
-    buyAmountWethWei: String(authorization.buyAmountWethWei),
-    sellAmountSentinelWei: String(authorization.sellAmountSentinelWei),
-  },
-  observedTotalGasCostWei: totalGasCost.toString(),
-  buy,
-  sell,
-  notice: 'Receipt verification only. The verifier never signs or broadcasts transactions.',
-};
+  const result = {
+    schemaVersion: 1,
+    verifiedAtUtc: new Date().toISOString(),
+    chainId: 8453,
+    poolManager: POOL_MANAGER,
+    poolId: POOL_ID,
+    expectedWallet: EXPECTED_WALLET,
+    authorization: {
+      authorizedBy: authorization.authorizedBy,
+      authorizedAtUtc: authorization.authorizedAtUtc,
+      maxWethPrincipalWei: String(authorization.maxWethPrincipalWei),
+      maxTotalGasCostWei: String(authorization.maxTotalGasCostWei),
+      maxSlippageBps: String(authorization.maxSlippageBps),
+      approvedRoute: authorization.approvedRoute,
+      buyAmountWethWei: String(authorization.buyAmountWethWei),
+      sellAmountSentinelWei: String(authorization.sellAmountSentinelWei),
+      buyTransactionHash: BUY_TX_HASH,
+      sellTransactionHash: SELL_TX_HASH,
+    },
+    observedTotalGasCostWei: totalGasCost.toString(),
+    buy,
+    sell,
+    notice: 'Receipt verification only. The verifier never signs or broadcasts transactions.',
+  };
 
-await mkdir(OUTPUT_DIR, { recursive: true });
-await writeFile(RECEIPTS_PATH, `${JSON.stringify(result, null, 2)}\n`);
-await writeFile(path.join(OUTPUT_DIR, 'README.md'), `# SENTINEL minimal buy/sell smoke-test evidence\n\n- Verified: ${result.verifiedAtUtc}\n- Buy transaction: \`${BUY_TX_HASH}\`\n- Sell transaction: \`${SELL_TX_HASH}\`\n- Pool ID: \`${POOL_ID}\`\n- Signer: \`${buy.signer}\`\n- Total gas cost (wei): \`${totalGasCost}\`\n\nBoth receipts succeeded, stayed within the recorded principal/gas authorization, and emitted canonical-pool Swap events in the expected directions. Slippage approval must be checked against the signed wallet quotes and independently reviewed.\n`);
-console.log(JSON.stringify(result, null, 2));
-await provider.destroy();
+  await mkdir(OUTPUT_DIR, { recursive: true });
+  await writeFile(RECEIPTS_PATH, `${JSON.stringify(result, null, 2)}\n`);
+  await writeFile(path.join(OUTPUT_DIR, 'README.md'), `# SENTINEL minimal buy/sell smoke-test evidence\n\n- Verified: ${result.verifiedAtUtc}\n- Buy transaction: \`${BUY_TX_HASH}\`\n- Sell transaction: \`${SELL_TX_HASH}\`\n- Pool ID: \`${POOL_ID}\`\n- Signer: \`${buy.signer}\`\n- Total gas cost (wei): \`${totalGasCost}\`\n\nBoth receipts succeeded, stayed within the recorded principal/gas authorization, and emitted canonical-pool Swap events in the expected directions. Slippage approval must be checked against the signed wallet quotes and independently reviewed.\n`);
+  console.log(JSON.stringify(result, null, 2));
+} finally {
+  await provider.destroy();
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "echo 'Skipping Python dependency installation for the Sentinel contract repository'",
+  "buildCommand": "mkdir -p public && cp docs/vercel-status.html public/index.html",
+  "outputDirectory": "public"
+}


### PR DESCRIPTION
## Summary

Closes the remaining code-review weaknesses in the SENTINEL external release-gate tooling.

### Changes
- Requires authorized buy and sell transaction hashes in `authorization.json`.
- Rejects environment overrides that differ from the recorded authorization.
- Removes fallback to previously generated receipt files.
- Fails closed when an authoritative gas price cannot be determined.
- Binds final receipt hashes unconditionally to the authorization.
- Validates EIP-191 beneficiary signatures as 65-byte signatures.
- Accepts variable-length EIP-1271 Safe signature bytes while retaining on-chain verification.
- Rejects repeated-character and placeholder-like signatures or references.
- Ensures the RPC provider is destroyed on success and failure.

## Security boundary

This PR does not sign, broadcast, authorize, or independently approve anything. The following external release gates remain intentionally human-controlled:
1. Four beneficiary wallet attestations.
2. Explicitly authorized minimal Base mainnet buy/sell transactions.
3. Independent release review and sign-off.

## Validation

Not run locally. GitHub Actions is validating the branch with:

- `node scripts/validate-sentinel-release-closure.mjs --mode=readiness`
- `node test/validate-pr-testing-claims.test.cjs`
- Repository build, security, adversarial-safety, and release-closure workflows

Final release validation is expected to remain blocked until authentic external evidence is supplied.