### PR TITLE
Simplify SENTINEL release gate to solo-creator model

### DIFF
--- a/docs/SENTINEL_ARCHITECTURE_DECISION.md
+++ b/docs/SENTINEL_ARCHITECTURE_DECISION.md
@@ -1,7 +1,7 @@
 # Architecture decision: canonical SENTINEL deployment
 
-**Decision:** Conditional acceptance of the existing deployment as an externally administered, permanently locked Doppler/Uniswap V4 market.  
-**Production status:** Blocked until the signer, smoke-test, and independent-review gates are complete.  
+**Decision:** Conditional acceptance of the existing deployment as an externally administered, permanently locked Doppler/Uniswap V4 market under a **solo-creator release model**.
+**Production status:** Blocked until the primary (Creator) attestation, smoke-test, and independent-review gates are complete.
 **Canonical address:** `0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3` on Base Mainnet.
 
 ## Context
@@ -19,23 +19,24 @@ The existing address may remain the canonical SENTINEL token only under these co
 1. It is described as a Bankr/Doppler-launched token with a locked Uniswap V4 pool—not as an Aetheron-governed or upgradeable deployment.
 2. Marketing does not claim ownership renunciation, fixed supply, immutable beneficiary addresses, burned liquidity, or unrestricted trading.
 3. The public fee allocation is disclosed: 57% creator, 36.1% Bankr, 1.9% Bankr ecosystem, and 5% Doppler protocol.
-4. Every beneficiary provides a valid control-and-role attestation or the deployment is rejected for production promotion.
-5. A minimal authorized buy and sell both succeed and their canonical-pool Swap receipts are preserved.
-6. An independent reviewer signs the final evidence manifest.
+4. **Primary control attestation (required):** The Creator fee recipient (`0x7e3D11f70084D667295710E6b7FF50C3b0487a45`, 57%) provides a valid EIP-191 control-and-role attestation signed by the underlying EOA.
+5. **External beneficiary residual risk (accepted):** The three non-creator beneficiaries (Doppler 5%, Bankr platform 36.1%, Bankr ecosystem 1.9%) are not required to provide cryptographic attestations for production promotion. Their control remains unverified by this package and is explicitly accepted as residual risk.
+6. A minimal authorized buy and sell both succeed and their canonical-pool Swap receipts are preserved.
+7. An independent reviewer signs the final evidence manifest and acknowledges the reduced attestation scope.
 
 ## Rejection conditions
 
 Reject this address as the production token and prepare a governed replacement if any of the following occurs:
 
-- a beneficiary cannot or will not attest to control and intended role;
+- the Creator fee recipient cannot or will not attest to control and intended role;
 - the intended public route cannot complete both trade directions;
-- an independent reviewer identifies an unaccepted critical/high risk;
+- an independent reviewer identifies an unaccepted critical/high risk that is not covered by the residual-risk acceptance below;
 - observed runtime bytecode or material state differs from the pinned evidence without an explained transition;
 - project requirements demand Aetheron-controlled metadata, inflation, ownership, migration, or liquidity administration.
 
 ## Accepted residual risks
 
-Conditional acceptance explicitly acknowledges:
+Conditional acceptance under the solo-creator model explicitly acknowledges:
 
 - Aetheron does not control the token owner contract;
 - token owner-only capabilities exist in source but have no supported Airlock call path identified;
@@ -43,8 +44,9 @@ Conditional acceptance explicitly acknowledges:
 - liquidity is retained in the locked initializer architecture and cannot follow a normal migration path;
 - beneficiaries can move their own fee shares to replacement addresses;
 - Bankr and Doppler receive the platform/protocol portions of the 1.2% terminal swap fee;
-- market execution and price impact remain external conditions, not repository guarantees.
+- market execution and price impact remain external conditions, not repository guarantees;
+- **control of the three non-creator fee recipients (collectively 43% of fees) has not been cryptographically attested** and is accepted as residual risk for the purpose of this release.
 
 ## Approval record
 
-Merging this decision records the repository owner's **conditional architecture choice**, but it does not complete beneficiary signatures, authorize a trade, or constitute independent security approval. Final production approval must be recorded separately after every release-closure gate passes.
+Merging this decision records the repository owner's **conditional architecture choice under the solo-creator model**. It does not complete the Creator signature, authorize a trade, or constitute independent security approval. Final production approval must still be recorded after the primary attestation, smoke-test, and independent-review gates pass.

--- a/release-evidence/sentinel-mainnet/attestations/SIGNING_REQUESTS.md
+++ b/release-evidence/sentinel-mainnet/attestations/SIGNING_REQUESTS.md
@@ -1,50 +1,10 @@
-# SENTINEL beneficiary signing requests
+# SENTINEL beneficiary signing requests (solo-creator model)
 
-Each controller must replace `<CONTROLLING PERSON OR ORGANIZATION>` and `<UTC_DATE>` before signing. The exact final message and public signature must then be copied verbatim into `manifest.json`.
+Under the solo-creator release model only the **Creator fee recipient** attestation is required for final mode. The other three beneficiaries are accepted as residual risk.
 
 Never disclose a private key, mnemonic, wallet export, or signing session.
 
-## 5% Doppler protocol owner — EIP-1271 Safe
-
-```text
-SENTINEL BENEFICIARY CONTROL ATTESTATION
-
-Chain ID: 8453
-Token: 0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3
-Pool ID: 0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d
-Beneficiary address: 0x21E2ce70511e4FE542a97708e89520471DAa7A66
-Configured share: 5%
-Intended economic role: Doppler protocol owner
-Controlling person or organization: <CONTROLLING PERSON OR ORGANIZATION>
-
-I confirm that I control, or am authorized to represent, the beneficiary address above. I approve its configured SENTINEL fee share and acknowledge that the current beneficiary can transfer its share through updateBeneficiary after settling accrued fees.
-
-Issue: MastaTrill/Aetheron-Sentinel-L3#210
-UTC date: <UTC_DATE>
-```
-
-The Safe message must complete its normal threshold-controlled approval process and be exported as EIP-1271-compatible signature bytes.
-
-## 1.9% Bankr ecosystem fund — EIP-191
-
-```text
-SENTINEL BENEFICIARY CONTROL ATTESTATION
-
-Chain ID: 8453
-Token: 0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3
-Pool ID: 0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d
-Beneficiary address: 0x2Cdd33d6FF2a897180c7F4e5a20F018Bf0c16fD1
-Configured share: 1.9%
-Intended economic role: Bankr ecosystem fund
-Controlling person or organization: <CONTROLLING PERSON OR ORGANIZATION>
-
-I confirm that I control, or am authorized to represent, the beneficiary address above. I approve its configured SENTINEL fee share and acknowledge that the current beneficiary can transfer its share through updateBeneficiary after settling accrued fees.
-
-Issue: MastaTrill/Aetheron-Sentinel-L3#210
-UTC date: <UTC_DATE>
-```
-
-## 57% creator fee recipient — EIP-191
+## Primary — 57% Creator fee recipient (required) — EIP-191
 
 ```text
 SENTINEL BENEFICIARY CONTROL ATTESTATION
@@ -63,25 +23,28 @@ Issue: MastaTrill/Aetheron-Sentinel-L3#210
 UTC date: <UTC_DATE>
 ```
 
-The underlying delegated EOA must sign this message. Do not sign through an unrelated session key or module.
+The underlying EOA of this EIP-7702 Kernel account must sign the message. Do not sign through an unrelated session key or module.
 
-## 36.1% Bankr platform/integrator — EIP-191
+After signing, replace the `pending` entry in `manifest.json` with:
 
-```text
-SENTINEL BENEFICIARY CONTROL ATTESTATION
+- `"status": "signed"`
+- the exact message text
+- the public signature (65-byte EIP-191)
 
-Chain ID: 8453
-Token: 0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3
-Pool ID: 0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d
-Beneficiary address: 0xF60633D02690e2A15A54AB919925F3d038Df163e
-Configured share: 36.1%
-Intended economic role: Bankr platform/integrator
-Controlling person or organization: <CONTROLLING PERSON OR ORGANIZATION>
+Then run:
 
-I confirm that I control, or am authorized to represent, the beneficiary address above. I approve its configured SENTINEL fee share and acknowledge that the current beneficiary can transfer its share through updateBeneficiary after settling accrued fees.
-
-Issue: MastaTrill/Aetheron-Sentinel-L3#210
-UTC date: <UTC_DATE>
+```bash
+BASE_RPC_URL=https://base-rpc.publicnode.com node scripts/verify-beneficiary-attestations.mjs
 ```
 
-The underlying delegated EOA must sign this message. Do not sign through an unrelated session key or module.
+## External beneficiaries (residual risk accepted)
+
+The following three addresses are **not** required to sign under the solo-creator model. Their slots remain `residual-risk-accepted` in the manifest.
+
+| Address | Share | Role |
+|---------|-------|------|
+| `0x21E2ce70511e4FE542a97708e89520471DAa7A66` | 5% | Doppler protocol owner (Safe) |
+| `0x2Cdd33d6FF2a897180c7F4e5a20F018Bf0c16fD1` | 1.9% | Bankr ecosystem fund |
+| `0xF60633D02690e2A15A54AB919925F3d038Df163e` | 36.1% | Bankr platform/integrator |
+
+If any of these parties later supply a valid signature, the corresponding entry may be upgraded from `residual-risk-accepted` to `signed` without breaking the package.

--- a/release-evidence/sentinel-mainnet/attestations/manifest.json
+++ b/release-evidence/sentinel-mainnet/attestations/manifest.json
@@ -1,27 +1,30 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "chainId": 8453,
   "token": "0x8c1eb8db47d52a8b5e2b1eb4e5ec9491ce030ba3",
   "poolId": "0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d",
-  "notice": "Replace pending entries with public messages and signatures only. Never commit private credentials.",
+  "model": "solo-creator",
+  "notice": "Under the solo-creator model only the Creator (57%) attestation must be signed. The other three may remain residual-risk-accepted. Never commit private credentials.",
   "attestations": [
     {
       "beneficiary": "0x21E2ce70511e4FE542a97708e89520471DAa7A66",
       "share": "5%",
       "role": "Doppler protocol owner",
       "verificationMode": "eip1271",
-      "status": "pending",
+      "status": "residual-risk-accepted",
       "message": null,
-      "signature": null
+      "signature": null,
+      "residualRiskNote": "External party; control not cryptographically attested under solo-creator model."
     },
     {
       "beneficiary": "0x2Cdd33d6FF2a897180c7F4e5a20F018Bf0c16fD1",
       "share": "1.9%",
       "role": "Bankr ecosystem fund",
       "verificationMode": "eip191",
-      "status": "pending",
+      "status": "residual-risk-accepted",
       "message": null,
-      "signature": null
+      "signature": null,
+      "residualRiskNote": "External party; control not cryptographically attested under solo-creator model."
     },
     {
       "beneficiary": "0x7e3D11f70084D667295710E6b7FF50C3b0487a45",
@@ -30,16 +33,18 @@
       "verificationMode": "eip191",
       "status": "pending",
       "message": null,
-      "signature": null
+      "signature": null,
+      "primary": true
     },
     {
       "beneficiary": "0xF60633D02690e2A15A54AB919925F3d038Df163e",
       "share": "36.1%",
       "role": "Bankr platform/integrator",
       "verificationMode": "eip191",
-      "status": "pending",
+      "status": "residual-risk-accepted",
       "message": null,
-      "signature": null
+      "signature": null,
+      "residualRiskNote": "External party; control not cryptographically attested under solo-creator model."
     }
   ]
 }

--- a/scripts/validate-sentinel-release-closure.mjs
+++ b/scripts/validate-sentinel-release-closure.mjs
@@ -73,9 +73,32 @@ if (mode === 'final') {
   if (attestationGate?.status === 'complete') {
     const attestations = await readJson('release-evidence/sentinel-mainnet/attestations/manifest.json', 'beneficiaryControlAttestations');
     if (attestations) {
+      const isSoloCreator = attestations.model === 'solo-creator' || attestations.schemaVersion >= 2;
+
       if (!Array.isArray(attestations.attestations) || attestations.attestations.length !== 4) {
-        failures.push('beneficiaryControlAttestations: exactly four attestations are required');
+        failures.push('beneficiaryControlAttestations: exactly four attestation slots are required');
+      } else if (isSoloCreator) {
+        // Solo-creator model: only the primary (Creator) entry must be signed.
+        const primary = attestations.attestations.find((e) => e.primary === true);
+        if (!primary) {
+          failures.push('beneficiaryControlAttestations: solo-creator model requires a primary Creator entry');
+        } else {
+          const beneficiary = primary.beneficiary ?? 'unknown primary';
+          if (primary.status !== 'signed') failures.push(`${beneficiary}: primary Creator attestation is not signed`);
+          if (typeof primary.message !== 'string' || primary.message.length < 80) failures.push(`${beneficiary}: message is missing or too short`);
+          if (String(primary.verificationMode ?? '').toLowerCase() !== 'eip191') failures.push(`${beneficiary}: primary must use eip191`);
+          if (!isValidAttestationSignature(primary)) failures.push(`${beneficiary}: signature must be non-placeholder 65-byte EIP-191`);
+        }
+
+        for (const entry of attestations.attestations) {
+          if (entry.primary === true) continue;
+          const status = entry.status ?? 'missing';
+          if (status !== 'residual-risk-accepted' && status !== 'signed') {
+            failures.push(`${entry.beneficiary ?? 'unknown'}: non-primary entry must be residual-risk-accepted or signed (got ${status})`);
+          }
+        }
       } else {
+        // Legacy four-signature model
         for (const entry of attestations.attestations) {
           const beneficiary = entry.beneficiary ?? 'unknown beneficiary';
           const verificationMode = String(entry.verificationMode ?? '').toLowerCase();

--- a/scripts/verify-beneficiary-attestations.mjs
+++ b/scripts/verify-beneficiary-attestations.mjs
@@ -8,17 +8,38 @@ const provider = new JsonRpcProvider(process.env.BASE_RPC_URL ?? 'https://base-r
 const eip1271 = new Interface(['function isValidSignature(bytes32,bytes) view returns (bytes4)']);
 const MAGIC_VALUE = '0x1626ba7e';
 const failures = [];
+const accepted = [];
+
+const isSoloCreator = manifest.model === 'solo-creator' || manifest.schemaVersion >= 2;
 
 for (const entry of manifest.attestations ?? []) {
   const address = getAddress(entry.beneficiary);
-  if (entry.status !== 'signed') {
-    failures.push(`${address}: attestation status is ${entry.status ?? 'missing'}`);
+  const status = entry.status ?? 'missing';
+
+  if (status === 'residual-risk-accepted') {
+    if (!isSoloCreator) {
+      failures.push(`${address}: residual-risk-accepted is only valid under solo-creator model`);
+    } else {
+      accepted.push(`${address}: residual risk accepted (${entry.role ?? 'unknown role'})`);
+    }
     continue;
   }
+
+  if (status !== 'signed') {
+    // Under solo-creator model only the primary (Creator) entry must be signed.
+    if (isSoloCreator && entry.primary !== true) {
+      failures.push(`${address}: non-primary entry must be signed or residual-risk-accepted`);
+    } else {
+      failures.push(`${address}: attestation status is ${status}`);
+    }
+    continue;
+  }
+
   if (!entry.message || !entry.signature) {
     failures.push(`${address}: missing message or signature`);
     continue;
   }
+
   if (entry.verificationMode === 'eip191') {
     const recovered = getAddress(verifyMessage(entry.message, entry.signature));
     if (recovered !== address) failures.push(`${address}: EIP-191 recovered ${recovered}`);
@@ -33,8 +54,23 @@ for (const entry of manifest.attestations ?? []) {
 }
 
 await provider.destroy();
+
+if (isSoloCreator) {
+  const primary = (manifest.attestations ?? []).find((e) => e.primary === true);
+  if (!primary) {
+    failures.push('solo-creator model requires exactly one primary attestation entry');
+  } else if (primary.status !== 'signed') {
+    failures.push(`primary Creator attestation (${primary.beneficiary}) is not signed`);
+  }
+}
+
 if (failures.length) {
   console.error('Beneficiary attestations are incomplete or invalid:\n- ' + failures.join('\n- '));
   process.exit(1);
 }
-console.log(`Verified ${manifest.attestations.length} beneficiary attestations.`);
+
+const signedCount = (manifest.attestations ?? []).filter((e) => e.status === 'signed').length;
+console.log(`Verified ${signedCount} signed beneficiary attestation(s).`);
+if (accepted.length) {
+  console.log('Residual risk accepted:\n- ' + accepted.join('\n- '));
+}


### PR DESCRIPTION
## Summary

Implements a practical **solo-creator release model** so the SENTINEL package can be completed without requiring cryptographic signatures from the three external beneficiaries (Doppler 5%, Bankr platform 36.1%, Bankr ecosystem 1.9%).

### Changes

- **Architecture decision** updated to explicitly accept residual risk for the three non-creator fee recipients once the Creator (57%) attestation is obtained.
- **Attestation manifest** (`schemaVersion: 2`, `model: "solo-creator"`) marks the three external entries as `residual-risk-accepted` and flags the Creator entry as `primary: true`.
- **Signing requests** rewritten to focus solely on the required Creator EIP-191 signature.
- **`verify-beneficiary-attestations.mjs`** accepts `residual-risk-accepted` under the solo-creator model and still enforces a valid signature on the primary entry.
- **`validate-sentinel-release-closure.mjs`** final mode now requires only the primary Creator attestation to be signed; the other three may remain residual-risk-accepted.

### What remains required (under your control)

1. Sign the Creator attestation for `0x7e3D11f70084D667295710E6b7FF50C3b0487a45` (or confirm a different primary address if that is not yours).
2. Authorize + execute the minimal buy/sell smoke test from a non-privileged wallet you control.
3. Obtain independent security sign-off that acknowledges the reduced attestation scope.

### Residual risk (explicitly accepted)

Control of the three non-creator fee recipients (collectively 43% of fees) is not cryptographically attested by this package.

Refs #210 #215