### PR TITLE
fix: restore Vercel Next.js production build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "buildCommand": "npm run build",
+  "buildCommand": "npm run build:web",
   "installCommand": "npm install --legacy-peer-deps",
   "rewrites": [
     {


### PR DESCRIPTION
## What changed
- Point Vercel at `npm run build:web` so it builds the root Next.js application.
- Leave the nested subgraph build available through the existing root `npm run build` workflow without using it for web deployment.

## Root cause
The production deployment ran `npm run build`, which delegates to `npm --prefix sentinel-l3-v1.0 run build`. That nested script calls `graph build`, but Vercel only installed the root package dependencies, so the build failed with `graph: command not found` and exit code 127.

## Expected result
Vercel now runs the root `next build` command through `build:web`.