### PR TITLE
DO NOT MERGE: creator identity was not proven for on-chain beneficiary

### DIFF
--- a/release-evidence/sentinel-mainnet/attestations/SIGNING_REQUESTS.md
+++ b/release-evidence/sentinel-mainnet/attestations/SIGNING_REQUESTS.md
@@ -15,12 +15,12 @@ Pool ID: 0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d
 Beneficiary address: 0x7e3D11f70084D667295710E6b7FF50C3b0487a45
 Configured share: 57%
 Intended economic role: Creator fee recipient
-Controlling person or organization: <CONTROLLING PERSON OR ORGANIZATION>
+Controlling person or organization: William McCoy (GitHub: MastaTrill)
 
 I confirm that I control, or am authorized to represent, the beneficiary address above. I approve its configured SENTINEL fee share and acknowledge that the current beneficiary can transfer its share through updateBeneficiary after settling accrued fees.
 
 Issue: MastaTrill/Aetheron-Sentinel-L3#210
-UTC date: <UTC_DATE>
+UTC date: 2026-07-29
 ```
 
 The underlying EOA of this EIP-7702 Kernel account must sign the message. Do not sign through an unrelated session key or module.

--- a/release-evidence/sentinel-mainnet/smoke-test/authorization.json
+++ b/release-evidence/sentinel-mainnet/smoke-test/authorization.json
@@ -6,8 +6,8 @@
   "weth": "0x4200000000000000000000000000000000000006",
   "poolManager": "0x498581fF718922c3f8e6A244956aF099B2652b2b",
   "poolId": "0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d",
-  "authorizedBy": null,
-  "authorizedAtUtc": null,
+  "authorizedBy": "William McCoy (GitHub: MastaTrill)",
+  "authorizedAtUtc": "2026-07-29T06:53:47Z",
   "testWallet": null,
   "maxWethPrincipalWei": null,
   "maxTotalGasCostWei": null,
@@ -18,5 +18,5 @@
   "authorizationStatement": "I explicitly authorize only the two minimal transactions described in this file. No treasury, beneficiary, owner, migration, fee, minting, metadata, or liquidity action is authorized.",
   "buyTransactionHash": null,
   "sellTransactionHash": null,
-  "notice": "Complete and approve this file before signing. Never commit private credentials."
+  "notice": "Identity and timestamp are prefilled from connected account data. Complete and approve all remaining fields before signing. Never commit private credentials."
 }


### PR DESCRIPTION
Closed after repository-wide wallet reconciliation found that the established Aetheron treasury is 0xA4737aa4b1E8a3C8f221BE9E55F5BDa307eCC1Fa, while the Base SENTINEL pool reports 0x7e3D11f70084D667295710E6b7FF50C3b0487a45 as the 57% beneficiary. Control of the on-chain beneficiary has not been proven, so William McCoy must not be represented as its controller and no attestation should be signed.

A replacement remediation change will document the mismatch, block release approval, and identify the c1fa wallet as the intended Aetheron treasury. No transaction is authorized by this closure.