### PR TITLE
Prepare fail-closed SENTINEL beneficiary remediation

### DIFF
--- a/docs/SENTINEL_BENEFICIARY_REMEDIATION_RUNBOOK.md
+++ b/docs/SENTINEL_BENEFICIARY_REMEDIATION_RUNBOOK.md
@@ -1,0 +1,108 @@
+# SENTINEL 57% beneficiary remediation runbook
+
+**Network:** Base Mainnet (`8453`)  
+**Initializer:** `0xD59cE43E53D69F190E15d9822Fb4540dCcc91178`  
+**Pool ID:** `0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d`  
+**Current 57% beneficiary:** `0x7e3D11f70084D667295710E6b7FF50C3b0487a45`  
+**Intended Aetheron treasury:** `0xA4737aa4b1E8a3C8f221BE9E55F5BDa307eCC1Fa`
+
+## Purpose
+
+Move the existing 57% creator-fee share to the established Aetheron treasury without falsely claiming control, losing the fee cutoff, or allowing repository automation to sign or broadcast a transaction.
+
+This runbook prepares and verifies the remediation. It does not authorize it.
+
+## Verified contract behavior
+
+The verified initializer inherits `FeesManager`, which exposes:
+
+- `collectFees(bytes32 poolId)` — collects current pool fees, increments cumulative accounting, and releases the caller's beneficiary share;
+- `updateBeneficiary(bytes32 poolId,address newBeneficiary)` — releases already-accounted fees, initializes the new beneficiary checkpoint when needed, transfers all of `msg.sender`'s shares, zeros the old share, and emits `UpdateBeneficiary`.
+
+`updateBeneficiary` does not call the pool-fee collection routine. To create an unambiguous economic cutoff, the current beneficiary must call `collectFees` before transferring the share.
+
+## Hard prerequisites
+
+All conditions must be satisfied before any signing request is presented:
+
+- [ ] A public cryptographic proof establishes control of `0x7e3D...7a45` by the person or organization authorizing remediation.
+- [ ] Control of the intended treasury `0xA473...C1Fa` is independently confirmed.
+- [ ] Two independent Base RPC providers agree on the pinned block, current 57% share, target zero share, fee accounting, and both read-only simulations.
+- [ ] Exact maximum gas cost and expiry are written into the authorization record.
+- [ ] The unsigned transaction `to`, `data`, `value`, chain ID, and execution order are independently reviewed.
+- [ ] No private key, mnemonic, wallet export, session key, or authenticated RPC credential appears in GitHub, chat, CI output, or shell history.
+
+## Read-only preflight
+
+Run:
+
+```bash
+BASE_RPC_URLS="https://mainnet.base.org,https://base-rpc.publicnode.com" \
+  node scripts/prepare-sentinel-beneficiary-remediation.mjs \
+  | tee /tmp/sentinel-beneficiary-remediation-preflight.json
+```
+
+The script fails closed unless:
+
+1. both RPC providers reproduce the same pinned state;
+2. the current address owns exactly `0.57e18` shares;
+3. the intended treasury owns zero shares before remediation;
+4. `collectFees(poolId)` succeeds under a read-only call from the current beneficiary; and
+5. `updateBeneficiary(poolId,treasury)` succeeds under a read-only call from the current beneficiary.
+
+A successful simulation proves only that the contract would accept the stated caller. It does not prove that the operator controls that caller.
+
+## Required transaction order
+
+### Transaction 1 — establish fee cutoff
+
+The current beneficiary calls:
+
+```solidity
+collectFees(0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d)
+```
+
+Wait for a confirmed receipt. Verify the `Collect` event and any `Release` event for the current beneficiary before proceeding.
+
+### Transaction 2 — transfer the 57% share
+
+After Transaction 1 confirms, the same current beneficiary calls:
+
+```solidity
+updateBeneficiary(
+  0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d,
+  0xA4737aa4b1E8a3C8f221BE9E55F5BDa307eCC1Fa
+)
+```
+
+Wait for a confirmed receipt and verify the `UpdateBeneficiary` event.
+
+Do not batch the calls unless the exact smart-account execution path and atomic failure behavior are independently reviewed.
+
+## Post-transaction verification
+
+Pin the update receipt block and reproduce through two independent RPC providers:
+
+- [ ] old beneficiary shares equal `0`;
+- [ ] Aetheron treasury shares equal `570000000000000000`;
+- [ ] pool ID and initializer match the canonical deployment;
+- [ ] `UpdateBeneficiary` identifies the exact old and new addresses;
+- [ ] both transaction receipts succeeded;
+- [ ] block hashes and transaction hashes match across providers;
+- [ ] no unrelated ownership, liquidity, migration, minting, metadata, or fee-recipient state changed.
+
+Store only public evidence: authorization record, transaction hashes, receipts, block identifiers, event decoding, two-RPC reads, and reviewer sign-off.
+
+## Failure paths
+
+Stop and retain the release block when:
+
+- control of `0x7e3D...7a45` cannot be proven;
+- either simulation reverts;
+- the target treasury already has an unexpected share;
+- RPC providers disagree;
+- the fee-collection receipt fails or cannot be decoded;
+- transaction parameters differ from the reviewed authorization; or
+- an independent reviewer identifies an unresolved material risk.
+
+If control is unavailable, the only acceptable next path is an explicitly approved replacement launch or redeployment with the correct treasury configured from inception. Repository edits cannot repair the deployed state.

--- a/release-evidence/sentinel-mainnet/beneficiary-remediation/authorization.json
+++ b/release-evidence/sentinel-mainnet/beneficiary-remediation/authorization.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": 1,
+  "network": {
+    "name": "Base Mainnet",
+    "chainId": 8453
+  },
+  "initializer": "0xD59cE43E53D69F190E15d9822Fb4540dCcc91178",
+  "poolId": "0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d",
+  "currentBeneficiary": "0x7e3D11f70084D667295710E6b7FF50C3b0487a45",
+  "intendedTreasury": "0xA4737aa4b1E8a3C8f221BE9E55F5BDa307eCC1Fa",
+  "executionOrder": [
+    "collectFees",
+    "updateBeneficiary"
+  ],
+  "controllerProof": {
+    "status": "missing",
+    "publicMessage": null,
+    "publicSignature": null,
+    "verifiedSigner": null,
+    "verifiedAtUtc": null
+  },
+  "authorization": {
+    "status": "not-authorized",
+    "authorizedBy": null,
+    "authorizedAtUtc": null,
+    "expiresAtUtc": null,
+    "maximumTotalGasCostWei": null,
+    "approvedPinnedBlock": null,
+    "approvedPreflightSha256": null,
+    "statement": "I authorize only the two exact transactions recorded here, in the stated order, after independent review. No ownership, migration, minting, metadata, liquidity, beneficiary other than the 57% creator slot, or unrelated fee action is authorized."
+  },
+  "transactions": {
+    "collectFees": {
+      "from": "0x7e3D11f70084D667295710E6b7FF50C3b0487a45",
+      "to": "0xD59cE43E53D69F190E15d9822Fb4540dCcc91178",
+      "valueWei": "0",
+      "data": "0x817db73b05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d",
+      "transactionHash": null,
+      "blockNumber": null,
+      "blockHash": null,
+      "receiptStatus": null
+    },
+    "updateBeneficiary": {
+      "from": "0x7e3D11f70084D667295710E6b7FF50C3b0487a45",
+      "to": "0xD59cE43E53D69F190E15d9822Fb4540dCcc91178",
+      "valueWei": "0",
+      "data": "0xd44f673805d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d000000000000000000000000a4737aa4b1e8a3c8f221be9e55f5bda307ecc1fa",
+      "transactionHash": null,
+      "blockNumber": null,
+      "blockHash": null,
+      "receiptStatus": null
+    }
+  },
+  "independentReview": {
+    "status": "missing",
+    "reviewer": null,
+    "reviewedCommit": null,
+    "reviewedAtUtc": null,
+    "signoffReference": null
+  },
+  "notice": "This file is fail-closed. Null fields do not authorize signing or broadcasting. Never commit private credentials or wallet-session material."
+}

--- a/scripts/prepare-sentinel-beneficiary-remediation.mjs
+++ b/scripts/prepare-sentinel-beneficiary-remediation.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+import { Interface, JsonRpcProvider, getAddress } from 'ethers';
+
+const CHAIN_ID = 8453;
+const INITIALIZER = getAddress('0xD59cE43E53D69F190E15d9822Fb4540dCcc91178');
+const POOL_ID = '0x05d37c029565268ba474749d6142f64511861910671d836460ab56ef26c7157d';
+const CURRENT_BENEFICIARY = getAddress('0x7e3D11f70084D667295710E6b7FF50C3b0487a45');
+const INTENDED_TREASURY = getAddress('0xA4737aa4b1E8a3C8f221BE9E55F5BDa307eCC1Fa');
+const EXPECTED_CREATOR_SHARES = 570000000000000000n;
+const WAD = 1000000000000000000n;
+
+const rpcUrls = (process.env.BASE_RPC_URLS ??
+  'https://mainnet.base.org,https://base-rpc.publicnode.com')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+if (rpcUrls.length < 2) {
+  throw new Error('BASE_RPC_URLS must contain at least two independent Base RPC endpoints');
+}
+
+const initializer = new Interface([
+  'function collectFees(bytes32 poolId) returns (uint128 fees0, uint128 fees1)',
+  'function updateBeneficiary(bytes32 poolId,address newBeneficiary)',
+  'function getShares(bytes32 poolId,address beneficiary) view returns (uint256)',
+  'function getCumulatedFees0(bytes32 poolId) view returns (uint256)',
+  'function getCumulatedFees1(bytes32 poolId) view returns (uint256)',
+  'function getLastCumulatedFees0(bytes32 poolId,address beneficiary) view returns (uint256)',
+  'function getLastCumulatedFees1(bytes32 poolId,address beneficiary) view returns (uint256)',
+]);
+
+const providers = rpcUrls.map(
+  (url) => new JsonRpcProvider(url, CHAIN_ID, { staticNetwork: true }),
+);
+
+const collectFeesData = initializer.encodeFunctionData('collectFees', [POOL_ID]);
+const updateBeneficiaryData = initializer.encodeFunctionData('updateBeneficiary', [
+  POOL_ID,
+  INTENDED_TREASURY,
+]);
+
+function serialize(value) {
+  return typeof value === 'bigint' ? value.toString() : value;
+}
+
+async function read(provider, functionName, args, blockTag) {
+  const data = initializer.encodeFunctionData(functionName, args);
+  const raw = await provider.call({ to: INITIALIZER, data }, blockTag);
+  return initializer.decodeFunctionResult(functionName, raw);
+}
+
+async function inspectProvider(provider, url, blockTag) {
+  const network = await provider.getNetwork();
+  if (Number(network.chainId) !== CHAIN_ID) {
+    throw new Error(`${url} returned chain ID ${network.chainId}, expected ${CHAIN_ID}`);
+  }
+
+  const block = await provider.getBlock(blockTag);
+  if (!block) throw new Error(`${url} could not read pinned block ${blockTag}`);
+
+  const [currentShares] = await read(
+    provider,
+    'getShares',
+    [POOL_ID, CURRENT_BENEFICIARY],
+    blockTag,
+  );
+  const [targetShares] = await read(
+    provider,
+    'getShares',
+    [POOL_ID, INTENDED_TREASURY],
+    blockTag,
+  );
+  const [cumulatedFees0] = await read(provider, 'getCumulatedFees0', [POOL_ID], blockTag);
+  const [cumulatedFees1] = await read(provider, 'getCumulatedFees1', [POOL_ID], blockTag);
+  const [lastCumulatedFees0] = await read(
+    provider,
+    'getLastCumulatedFees0',
+    [POOL_ID, CURRENT_BENEFICIARY],
+    blockTag,
+  );
+  const [lastCumulatedFees1] = await read(
+    provider,
+    'getLastCumulatedFees1',
+    [POOL_ID, CURRENT_BENEFICIARY],
+    blockTag,
+  );
+
+  const pendingHeldFees0 =
+    ((cumulatedFees0 - lastCumulatedFees0) * currentShares) / WAD;
+  const pendingHeldFees1 =
+    ((cumulatedFees1 - lastCumulatedFees1) * currentShares) / WAD;
+
+  let collectSimulation;
+  try {
+    const raw = await provider.call(
+      {
+        to: INITIALIZER,
+        from: CURRENT_BENEFICIARY,
+        data: collectFeesData,
+      },
+      blockTag,
+    );
+    const [newlyCollectedFees0, newlyCollectedFees1] =
+      initializer.decodeFunctionResult('collectFees', raw);
+    collectSimulation = {
+      success: true,
+      newlyCollectedFees0,
+      newlyCollectedFees1,
+    };
+  } catch (error) {
+    collectSimulation = {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  let updateSimulation;
+  try {
+    await provider.call(
+      {
+        to: INITIALIZER,
+        from: CURRENT_BENEFICIARY,
+        data: updateBeneficiaryData,
+      },
+      blockTag,
+    );
+    updateSimulation = { success: true };
+  } catch (error) {
+    updateSimulation = {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  return {
+    rpcUrl: url,
+    blockNumber: block.number,
+    blockHash: block.hash,
+    blockTimestamp: block.timestamp,
+    currentShares,
+    targetShares,
+    cumulatedFees0,
+    cumulatedFees1,
+    lastCumulatedFees0,
+    lastCumulatedFees1,
+    pendingHeldFees0,
+    pendingHeldFees1,
+    collectSimulation,
+    updateSimulation,
+  };
+}
+
+try {
+  const latestBlocks = await Promise.all(providers.map((provider) => provider.getBlockNumber()));
+  const pinnedBlock = Math.min(...latestBlocks);
+  const observations = await Promise.all(
+    providers.map((provider, index) => inspectProvider(provider, rpcUrls[index], pinnedBlock)),
+  );
+
+  const first = observations[0];
+  const consistent = observations.every(
+    (observation) =>
+      observation.blockHash === first.blockHash &&
+      observation.currentShares === first.currentShares &&
+      observation.targetShares === first.targetShares &&
+      observation.cumulatedFees0 === first.cumulatedFees0 &&
+      observation.cumulatedFees1 === first.cumulatedFees1 &&
+      observation.lastCumulatedFees0 === first.lastCumulatedFees0 &&
+      observation.lastCumulatedFees1 === first.lastCumulatedFees1 &&
+      observation.collectSimulation.success === first.collectSimulation.success &&
+      observation.updateSimulation.success === first.updateSimulation.success,
+  );
+
+  const checks = {
+    twoRpcAgreement: consistent,
+    currentShareIsExactly57Percent: first.currentShares === EXPECTED_CREATOR_SHARES,
+    intendedTreasuryHasNoExistingShare: first.targetShares === 0n,
+    collectFeesSimulationSucceeds: first.collectSimulation.success,
+    updateBeneficiarySimulationSucceeds: first.updateSimulation.success,
+  };
+  const readyForExplicitAuthorization = Object.values(checks).every(Boolean);
+
+  const output = {
+    schemaVersion: 1,
+    generatedAtUtc: new Date().toISOString(),
+    network: { name: 'Base Mainnet', chainId: CHAIN_ID },
+    initializer: INITIALIZER,
+    poolId: POOL_ID,
+    currentBeneficiary: CURRENT_BENEFICIARY,
+    intendedTreasury: INTENDED_TREASURY,
+    pinnedBlock,
+    checks,
+    status: readyForExplicitAuthorization
+      ? 'READY_FOR_EXPLICIT_AUTHORIZATION'
+      : 'BLOCKED',
+    requiredExecutionOrder: [
+      'Obtain cryptographic proof that the operator controls the current beneficiary.',
+      'Explicitly authorize exact gas and spending limits for both calls.',
+      'Call collectFees(poolId) from the current beneficiary to establish a fee cutoff.',
+      'After the collection confirms, call updateBeneficiary(poolId,intendedTreasury) from the same beneficiary.',
+      'Verify the new 57% share through two independent RPC providers and preserve both receipts.',
+    ],
+    unsignedTransactions: {
+      collectFees: {
+        chainId: CHAIN_ID,
+        from: CURRENT_BENEFICIARY,
+        to: INITIALIZER,
+        value: '0',
+        data: collectFeesData,
+        authorized: false,
+      },
+      updateBeneficiary: {
+        chainId: CHAIN_ID,
+        from: CURRENT_BENEFICIARY,
+        to: INITIALIZER,
+        value: '0',
+        data: updateBeneficiaryData,
+        authorized: false,
+      },
+    },
+    observations,
+    safetyNotice:
+      'This output is read-only and unsigned. It does not prove wallet control and does not authorize signing or broadcasting.',
+  };
+
+  console.log(JSON.stringify(output, serialize, 2));
+  if (!readyForExplicitAuthorization) process.exitCode = 1;
+} finally {
+  await Promise.all(providers.map((provider) => provider.destroy()));
+}

--- a/scripts/prepare-sentinel-beneficiary-remediation.mjs
+++ b/scripts/prepare-sentinel-beneficiary-remediation.mjs
@@ -45,7 +45,7 @@ function serialize(value) {
 
 async function read(provider, functionName, args, blockTag) {
   const data = initializer.encodeFunctionData(functionName, args);
-  const raw = await provider.call({ to: INITIALIZER, data }, blockTag);
+  const raw = await provider.call({ to: INITIALIZER, data, blockTag });
   return initializer.decodeFunctionResult(functionName, raw);
 }
 
@@ -92,14 +92,12 @@ async function inspectProvider(provider, url, blockTag) {
 
   let collectSimulation;
   try {
-    const raw = await provider.call(
-      {
-        to: INITIALIZER,
-        from: CURRENT_BENEFICIARY,
-        data: collectFeesData,
-      },
+    const raw = await provider.call({
+      to: INITIALIZER,
+      from: CURRENT_BENEFICIARY,
+      data: collectFeesData,
       blockTag,
-    );
+    });
     const [newlyCollectedFees0, newlyCollectedFees1] =
       initializer.decodeFunctionResult('collectFees', raw);
     collectSimulation = {
@@ -116,14 +114,12 @@ async function inspectProvider(provider, url, blockTag) {
 
   let updateSimulation;
   try {
-    await provider.call(
-      {
-        to: INITIALIZER,
-        from: CURRENT_BENEFICIARY,
-        data: updateBeneficiaryData,
-      },
+    await provider.call({
+      to: INITIALIZER,
+      from: CURRENT_BENEFICIARY,
+      data: updateBeneficiaryData,
       blockTag,
-    );
+    });
     updateSimulation = { success: true };
   } catch (error) {
     updateSimulation = {
@@ -226,5 +222,5 @@ try {
   console.log(JSON.stringify(output, serialize, 2));
   if (!readyForExplicitAuthorization) process.exitCode = 1;
 } finally {
-  await Promise.all(providers.map((provider) => provider.destroy()));
+  for (const provider of providers) provider.destroy();
 }


### PR DESCRIPTION
## Summary

Adds the safe execution boundary for issue #215 without signing or broadcasting a transaction.

### Changes

- Adds a two-RPC, block-pinned read-only preflight for the canonical initializer and pool.
- Simulates both required calls from the current 57% beneficiary.
- Verifies the current share is exactly 57% and the intended Aetheron treasury has no existing share.
- Generates the exact unsigned `collectFees` and `updateBeneficiary` transaction data.
- Adds a fail-closed authorization record with controller proof, gas limit, expiry, receipts, and independent-review fields unset.
- Documents the required order: collect current fees first, then transfer the beneficiary share.

## Important source finding

`updateBeneficiary` releases fees already reflected in initializer accounting, but it does not invoke the pool-fee collection routine. `collectFees(poolId)` must therefore confirm first to establish a clean economic cutoff before `updateBeneficiary(poolId, treasury)`.

## Safety boundary

This PR:

- does not claim that William McCoy controls `0x7e3D...7a45`;
- does not authorize signing or broadcasting;
- does not include or request private credentials;
- does not close #215;
- fails closed until public controller proof, exact authorization limits, two receipts, two-RPC post-state evidence, and independent review exist.

## Required external completion

1. Prove control of `0x7e3D...7a45` cryptographically.
2. Run the preflight and preserve its digest.
3. Complete explicit transaction authorization with maximum gas cost and expiry.
4. Obtain independent review.
5. Execute `collectFees`, then `updateBeneficiary`, from the current beneficiary.
6. Preserve and independently reproduce both receipts and the resulting 57% treasury share.

Refs #215 and #210.